### PR TITLE
Run `sct_compute_compression` only once

### DIFF
--- a/scripts/process_data_dcm-zurich.sh
+++ b/scripts/process_data_dcm-zurich.sh
@@ -191,25 +191,19 @@ else
         echo "${SUBJECT}: ${sex}"
 
         # TODO: test without angle correction too
-        # Compute compression morphometrics for diameter_AP with and without normalization to PAM50
-        sct_compute_compression -i ${file_t2_ax_seg}.nii.gz -vertfile ${file_t2_ax_seg}_labeled.nii.gz -l ${file_compression}.nii.gz -normalize-hc 1 -sex ${sex} -o ${PATH_RESULTS}/${file_t2_ax}_diameter_AP_norm.csv
-        sct_compute_compression -i ${file_t2_ax_seg}.nii.gz -vertfile ${file_t2_ax_seg}_labeled.nii.gz -l ${file_compression}.nii.gz -normalize-hc 0 -o ${PATH_RESULTS}/${file_t2_ax}_diameter_AP.csv
-
-        # Compute compression morphometrics for cross-sectional area with and without normalization
-        sct_compute_compression -i ${file_t2_ax_seg}.nii.gz -vertfile ${file_t2_ax_seg}_labeled.nii.gz -l ${file_compression}.nii.gz -normalize-hc 1 -sex ${sex} -metric area -o ${PATH_RESULTS}/${file_t2_ax}_area_norm.csv
-        sct_compute_compression -i ${file_t2_ax_seg}.nii.gz -vertfile ${file_t2_ax_seg}_labeled.nii.gz -l ${file_compression}.nii.gz -normalize-hc 0 -metric area -o ${PATH_RESULTS}/${file_t2_ax}_area.csv
-
-        # Compute compression morphometrics for diameter_RL with and without normalization
-        sct_compute_compression -i ${file_t2_ax_seg}.nii.gz -vertfile ${file_t2_ax_seg}_labeled.nii.gz -l ${file_compression}.nii.gz -normalize-hc 1 -sex ${sex} -metric diameter_RL -o ${PATH_RESULTS}/${file_t2_ax}_diameter_RL_norm.csv
-        sct_compute_compression -i ${file_t2_ax_seg}.nii.gz -vertfile ${file_t2_ax_seg}_labeled.nii.gz -l ${file_compression}.nii.gz -normalize-hc 0 -metric diameter_RL -o ${PATH_RESULTS}/${file_t2_ax}_diameter_RL.csv
-
-        # Compute compression morphometrics for eccentricity with and without normalization
-        sct_compute_compression -i ${file_t2_ax_seg}.nii.gz -vertfile ${file_t2_ax_seg}_labeled.nii.gz -l ${file_compression}.nii.gz -normalize-hc 1 -sex ${sex} -metric eccentricity -o ${PATH_RESULTS}/${file_t2_ax}_eccentricity_norm.csv
-        sct_compute_compression -i ${file_t2_ax_seg}.nii.gz -vertfile ${file_t2_ax_seg}_labeled.nii.gz -l ${file_compression}.nii.gz -normalize-hc 0 -metric eccentricity -o ${PATH_RESULTS}/${file_t2_ax}_eccentricity.csv
-
-        # Compute compression morphometrics for solidity with and without normalization
-        sct_compute_compression -i ${file_t2_ax_seg}.nii.gz -vertfile ${file_t2_ax_seg}_labeled.nii.gz -l ${file_compression}.nii.gz -normalize-hc 1 -sex ${sex} -metric solidity -o ${PATH_RESULTS}/${file_t2_ax}_solidity_norm.csv
-        sct_compute_compression -i ${file_t2_ax_seg}.nii.gz -vertfile ${file_t2_ax_seg}_labeled.nii.gz -l ${file_compression}.nii.gz -normalize-hc 0 -metric solidity -o ${PATH_RESULTS}/${file_t2_ax}_solidity.csv
+        # Compute morphometric measures normalized to PAM50 template space
+        # Note: CSV file without normalization is also generated automatically
+        # Note: morphometric measures for individual subjects are appended to a single CSV file
+        # diameter_AP
+        sct_compute_compression -i ${file_t2_ax_seg}.nii.gz -vertfile ${file_t2_ax_seg}_labeled.nii.gz -l ${file_compression}.nii.gz -normalize-hc 1 -sex ${sex} -o ${PATH_RESULTS}/compression_metrics.csv
+        # cross-sectional area
+        sct_compute_compression -i ${file_t2_ax_seg}.nii.gz -vertfile ${file_t2_ax_seg}_labeled.nii.gz -l ${file_compression}.nii.gz -normalize-hc 1 -sex ${sex} -metric area -o ${PATH_RESULTS}/compression_metrics.csv
+        # diameter_RL
+        sct_compute_compression -i ${file_t2_ax_seg}.nii.gz -vertfile ${file_t2_ax_seg}_labeled.nii.gz -l ${file_compression}.nii.gz -normalize-hc 1 -sex ${sex} -metric diameter_RL -o ${PATH_RESULTS}/compression_metrics.csv
+        # eccentricity
+        sct_compute_compression -i ${file_t2_ax_seg}.nii.gz -vertfile ${file_t2_ax_seg}_labeled.nii.gz -l ${file_compression}.nii.gz -normalize-hc 1 -sex ${sex} -metric eccentricity -o ${PATH_RESULTS}/compression_metrics.csv
+        # solidity
+        sct_compute_compression -i ${file_t2_ax_seg}.nii.gz -vertfile ${file_t2_ax_seg}_labeled.nii.gz -l ${file_compression}.nii.gz -normalize-hc 1 -sex ${sex} -metric solidity ${PATH_RESULTS}/compression_metrics.csv
 
     fi
 fi

--- a/scripts/process_data_dcm-zurich.sh
+++ b/scripts/process_data_dcm-zurich.sh
@@ -203,7 +203,7 @@ else
         # eccentricity
         sct_compute_compression -i ${file_t2_ax_seg}.nii.gz -vertfile ${file_t2_ax_seg}_labeled.nii.gz -l ${file_compression}.nii.gz -normalize-hc 1 -sex ${sex} -metric eccentricity -o ${PATH_RESULTS}/compression_metrics.csv
         # solidity
-        sct_compute_compression -i ${file_t2_ax_seg}.nii.gz -vertfile ${file_t2_ax_seg}_labeled.nii.gz -l ${file_compression}.nii.gz -normalize-hc 1 -sex ${sex} -metric solidity ${PATH_RESULTS}/compression_metrics.csv
+        sct_compute_compression -i ${file_t2_ax_seg}.nii.gz -vertfile ${file_t2_ax_seg}_labeled.nii.gz -l ${file_compression}.nii.gz -normalize-hc 1 -sex ${sex} -metric solidity -o ${PATH_RESULTS}/compression_metrics.csv
 
     fi
 fi


### PR DESCRIPTION
This PR updates the processing script for `dcm-zurich` to be compatible with recent updates of `sct_compute_compression`.

**Context:**
`sct_compute_compression` now outputs both normalized and non-normalized values into a single file; moreover, values from individual subjects are aggregated into a single file; see https://github.com/spinalcordtoolbox/spinalcordtoolbox/pull/4003#discussion_r1246007753 and https://github.com/spinalcordtoolbox/spinalcordtoolbox/pull/4172

TODO:
- [x] wait https://github.com/spinalcordtoolbox/spinalcordtoolbox/pull/4172 is merged, then run the script on `dcm-zurich`

Fixes: https://github.com/sct-pipeline/dcm-metric-normalization/issues/17