### PR TITLE
Simplify `read_mscc` function

### DIFF
--- a/statistics/compute_stats_zurich.py
+++ b/statistics/compute_stats_zurich.py
@@ -373,7 +373,7 @@ def gen_chart_corr_mjoa_mscc(df, metric, mjoa, path_out=""):
     # MSCC with mJOA
     x_vals = df[mjoa]
     y_vals_mscc = df[metric]
-    metric_norm = METRICS_NORM[metric+'_PAM50_normalized']
+    metric_norm = metric+'_PAM50_normalized'
     y_vals_mscc_norm = df[metric_norm]
 
     r_mscc, p_mscc = compute_spearmans(x_vals, y_vals_mscc)

--- a/statistics/compute_stats_zurich.py
+++ b/statistics/compute_stats_zurich.py
@@ -1316,7 +1316,7 @@ def main():
                                   'manufacturers_model_name', 
                                   'manufacturer', 
                                   'stenosis',
-                                  'maximum_stenosis'
+                                  'maximum_stenosis'  # TODO to change
                                   #'weight',  # missing data - TODO - try this
                                   #'height'   # missing data - TODO - try this
                                   ])

--- a/statistics/compute_stats_zurich.py
+++ b/statistics/compute_stats_zurich.py
@@ -1294,7 +1294,7 @@ def main():
         # Initialize empty list
         dict_exclude_subj = []
 
-    logger.info('Exlcuded subjects: {}'.format(dict_exclude_subj))
+    logger.info('Excluded subjects: {}'.format(dict_exclude_subj))
 
     # Read participants.tsv file
     df_participants = read_participants_file(args.participants_file)

--- a/statistics/compute_stats_zurich.py
+++ b/statistics/compute_stats_zurich.py
@@ -340,7 +340,7 @@ def gen_chart_norm_vs_no_norm(df, metric, path_out=""):
     fig, ax = plt.subplots()
     #ax.set_box_aspect(1)
     # MSCC with mJOA
-    metric_norm = metric + '_norm'
+    metric_norm = metric+'_PAM50_normalized'
     x_vals = df[metric]
     y_vals_mscc = df[metric_norm]
     r_mscc, p_mscc = compute_spearmans(x_vals, y_vals_mscc)
@@ -373,7 +373,7 @@ def gen_chart_corr_mjoa_mscc(df, metric, mjoa, path_out=""):
     # MSCC with mJOA
     x_vals = df[mjoa]
     y_vals_mscc = df[metric]
-    metric_norm = metric + '_norm'
+    metric_norm = METRICS_NORM[metric+'_PAM50_normalized']
     y_vals_mscc_norm = df[metric_norm]
 
     r_mscc, p_mscc = compute_spearmans(x_vals, y_vals_mscc)
@@ -383,8 +383,8 @@ def gen_chart_corr_mjoa_mscc(df, metric, mjoa, path_out=""):
     logger.info(f'{metric_norm} ratio: Spearman r = {r_mscc_norm} and p = {p_mscc_norm}')
 
     sns.regplot(x=x_vals, y=y_vals_mscc, label=(metric+' ratio')) #ci=None,
-    sns.regplot(x=x_vals, y=y_vals_mscc_norm, color='crimson', label=(metric_norm + ' ratio')) # ci=None,
-    plt.ylabel((metric + ' ratio'), fontsize=16)
+    sns.regplot(x=x_vals, y=y_vals_mscc_norm, color='crimson', label=metric_norm) # ci=None,
+    plt.ylabel(metric, fontsize=16)
     plt.xlabel('mJOA', fontsize=16)
     plt.xlim([min(x_vals)-1, max(x_vals)+1])
     plt.tight_layout()
@@ -784,11 +784,11 @@ def predict_theurapeutic_decision(df_reg, df_reg_all, df_reg_norm, path_out):
     y_z_score = df_reg_all['therapeutic_decision'].astype(int)
     df_z_score = get_z_score(df_reg_all)
     # Do composite z_score for no norm between area, diameter_AP, diameter_RL
-    df_z_score['composite_zscore'] = df_z_score[['area_zscore', 'diameter_AP_zscore', 'diameter_RL_zscore']].mean(
+    df_z_score['composite_zscore'] = df_z_score[['area_ratio_zscore', 'diameter_AP_zscore', 'diameter_RL_zscore']].mean(
         axis=1)
     # Do composite z_score for norm between area, diameter_AP, diameter_RL TODO: maybe remove diameter RL?
     df_z_score['composite_zscore_norm'] = df_z_score[
-        ['area_norm_zscore', 'diameter_AP_norm_zscore', 'diameter_RL_norm_zscore']].mean(axis=1)
+        ['area_ratio_PAM50_normalized_zscore', 'diameter_AP_PAM50_normalized_zscore', 'diameter_RL_PAM50_normalized_zscore']].mean(axis=1)
     # mean_zscore = df_z_score.groupby('therapeutic_decision').agg([np.mean])
     # print(mean_zscore['diameter_AP_zscore'])
     mean_zscore = df_z_score.groupby('therapeutic_decision').agg([np.mean])
@@ -1071,7 +1071,7 @@ def compute_correlations_anatomical_and_morphometric_metrics(final_df, path_out)
 
     # Keep only anatomical and morphometric metrics
     metrics_dict = {'all_metrics': METRICS + METRICS_NORM + ['aSCOR', 'aMSCC'],
-                    'area': ['area', 'area_norm', 'aSCOR', 'aMSCC']}
+                    'area_ratio': ['area_ratio', 'area_ratio_PAM50_normalized', 'aSCOR', 'aMSCC']}
 
     # Either all metrics or only area
     for key, value in metrics_dict.items():
@@ -1287,7 +1287,7 @@ def main():
     final_df = final_df.replace({"previous_surgery": {'no': 0, 'yes': 1}})
 
     # Drop subjects with NaN values
-    final_df.dropna(axis=0, subset=['area_norm', 'total_mjoa', 'therapeutic_decision', 'age', 'height'], inplace=True)  # added height since significant predictor
+    final_df.dropna(axis=0, subset=['area_ratio_PAM50_normalized', 'total_mjoa', 'therapeutic_decision', 'age', 'height'], inplace=True)  # added height since significant predictor
     final_df.reset_index()
     number_subjects = len(final_df['participant_id'].to_list())
     logger.info(f'Number of subjects (after dropping subjects with NaN values): {number_subjects}')

--- a/statistics/compute_stats_zurich.py
+++ b/statistics/compute_stats_zurich.py
@@ -1101,10 +1101,10 @@ def merge_anatomical_morphological_final_for_pred(anatomical_df, motion_df, df_m
     final_df = final_df.set_index(['participant_id'])
     # Loop through levels to get the corresponding motion or anatomical metric or the maximum compressed level
     levels = np.unique(final_df['level'].to_list())
-    levels = levels[:-1]  # nan value
     for level in levels:
-        if not level == 'C1/C2':
-            level_conversion = 'C' + str(int(DICT_DISC_LABELS[level])-1)  # -1 to convert to zurich disc
+        # Skip C1/C2 level (2)
+        if not level == 2:
+            level_conversion = 'C' + str(int(level)-1)  # -1 to convert to zurich disc
             # Add scores at maximum level of compression
             final_df.loc[final_df.index[final_df['level']==level].tolist(), 'aSCOR'] = anatomical_df.loc[final_df.index[final_df['level']==level].tolist(), 'aSCOR_' + level_conversion]
             final_df.loc[final_df.index[final_df['level']==level].tolist(), 'aMSCC'] = anatomical_df.loc[final_df.index[final_df['level']==level].tolist(), 'aMSCC_' + level_conversion + 'toC2']

--- a/statistics/compute_stats_zurich.py
+++ b/statistics/compute_stats_zurich.py
@@ -76,9 +76,9 @@ def get_parser():
         )
     parser.add_argument(
         '-input-file',
-        required=False,
+        required=True,
         metavar='<file_path>',
-        help="Path to csv file with computed metrics")
+        help="Path to csv file with computed morphometric metrics")
     parser.add_argument(
         '-participants-file',
         required=True,

--- a/statistics/compute_stats_zurich.py
+++ b/statistics/compute_stats_zurich.py
@@ -1286,20 +1286,6 @@ def main():
         df_morphometrics_mscc = df_morphometrics_mscc.rename(columns={'subject': 'participant_id'})  # TODO remove when rerun
         # TODO remove subjects with no values (in read_MSCC)
 
-    # set index of participant to have the same index
-    df_morphometrics_mscc = df_morphometrics_mscc.set_index(['participant_id'])
-    # check if index is repeated, if so, print it
-    if df_morphometrics_mscc.index.duplicated().any():
-        repeated_indices_mscc = df_morphometrics_mscc.index[df_morphometrics_mscc.index.duplicated()].tolist()
-        print(repeated_indices_mscc)
-
-    # set index of participant to have the same index
-    df_morphometrics = df_morphometrics.set_index(['participant_id'])
-    # check if index is repeated, if so, print it
-    if df_morphometrics.index.duplicated().any():
-        repeated_indices = df_morphometrics.index[df_morphometrics.index.duplicated()].tolist()
-        print(repeated_indices)
-
     # Aggregate anatomical and motion scores from the maximum level of compression and merge them with computed
     # morphometrics
     df_clinical_all = merge_anatomical_morphological_final_for_pred(anatomical_df, motion_df, df_morphometrics)

--- a/statistics/compute_stats_zurich.py
+++ b/statistics/compute_stats_zurich.py
@@ -1290,6 +1290,7 @@ def main():
             except yaml.YAMLError as exc:
                 logger.error(exc)
     else:
+        # TODO: name dict_exclude_subj is confusing, it's not a dict, it's a list
         # Initialize empty list
         dict_exclude_subj = []
 

--- a/statistics/compute_stats_zurich.py
+++ b/statistics/compute_stats_zurich.py
@@ -40,12 +40,14 @@ logging.root.addHandler(hdlr)
 
 
 METRICS = [
-    'area',
-    'diameter_AP',
-    'diameter_RL',
-    'eccentricity',
-    'solidity'
+    'area_ratio',
+    'diameter_AP_ratio',
+    'diameter_RL_ratio',
+    'eccentricity_ratio',
+    'solidity_ratio',
 ]
+
+METRICS_NORM = [metric + '_PAM50_normalized' for metric in METRICS]
 
 DICT_DISC_LABELS = {
                     'C1/C2': 2,
@@ -55,9 +57,6 @@ DICT_DISC_LABELS = {
                     'C5/C6': 6,
                     'C6/C7': 7
 }
-
-
-METRICS_NORM = [metric + '_norm' for metric in METRICS]
 
 
 class SmartFormatter(argparse.HelpFormatter):

--- a/statistics/compute_stats_zurich.py
+++ b/statistics/compute_stats_zurich.py
@@ -176,10 +176,12 @@ def read_MSCC(path_results, exclude, df_participants, file_metric):
     return df_morphometrics
 
 
-def read_metric_file(file_path):
+def read_metric_file(file_path, dict_exclude_subj, df_participants):
     """
     Read CSV file with computed metrics and return Pandas DataFrame
-    :param file_path: path to participants.tsv file
+    :param file_path: path to the CSV file with computed metrics
+    :param dict_exclude_subj: list with subjects to exclude
+    :param df_participants: Pandas DataFrame with participants.tsv file
     :return: Pandas DataFrame
     """
     if os.path.isfile(file_path):
@@ -197,7 +199,46 @@ def read_metric_file(file_path):
     # Delete column 'filename'
     df_morphometrics.drop('filename', axis=1, inplace=True)
 
-    # print(df_participants)
+    # Merge df_participants['maximum_stenosis'] to df_morphometrics
+    df_morphometrics = pd.merge(df_morphometrics, df_participants[['participant_id', 'maximum_stenosis']],
+                                on='participant_id', how='left')
+    # Change coding of 'maximum_stenosis' column (e.g., from to 'C1/C2' to '2') based on DICT_DISC_LABELS
+    df_morphometrics['level'] = df_morphometrics['maximum_stenosis'].map(DICT_DISC_LABELS)
+    # NOTE: after this merge, df_morphometrics has the following columns:
+    #   'compression_level' - obtained from sct_compute_compression function based on vert labeling, example 5
+    #   'maximum_stenosis' - obtained from participants.tsv file, example 'C5/C6'
+    #   'level' - obtained from participants.tsv file and recoded using DICT_DISC_LABELS, example 6
+
+    # Subjects might have multiple levels of compression --> keep only the maximally compressed level (MCL)
+    # Get unique list of subjects
+    unique_subjects = df_morphometrics['participant_id'].unique().tolist()
+    # Loop across subjects
+    for sub in unique_subjects:
+        # First, get the maximally compressed level
+        max_level = df_participants.loc[df_participants['participant_id'] == sub, 'maximum_stenosis'].to_list()[0]
+        # Second, get all the compressed levels
+        all_compressed_levels = df_participants.loc[df_participants['participant_id'] == sub, 'stenosis'].to_list()[
+            0].split(', ')
+        # Third, get the index of the maximally compressed level
+        idx_max = all_compressed_levels.index(max_level)
+
+        # Get all rows of the subject from df_motphometrics
+        # Note: we are resetting the index to be able to use the index as a list, also we use the drop parameter to
+        # avoid the old index being added as a column
+        df_sub = df_morphometrics.loc[df_morphometrics['participant_id'] == sub].reset_index(drop=True)
+
+        # Check if the maximally compressed level is in the axial FOV (i.e., in the df_sub)
+        if idx_max not in df_sub.index.to_list():
+            print(f'Maximum level of compression {max_level} is not in axial FOV, excluding {sub}')
+            df_morphometrics.drop(df_morphometrics.loc[df_morphometrics['participant_id'] == sub].index, inplace=True)
+            dict_exclude_subj.append(sub)
+        # If the maximally compressed level is in the axial FOV, keep only this row
+        else:
+            # Get 'slice(I->S)' of df_sub with the maximally compressed level
+            slice_max = df_sub.loc[idx_max, 'slice(I->S)']
+            df_morphometrics = df_morphometrics.drop(df_morphometrics.loc[(df_morphometrics['participant_id'] == sub) &
+                                                          (df_morphometrics['slice(I->S)'] != slice_max)].index)
+
     return df_morphometrics
 
 
@@ -1269,14 +1310,7 @@ def main():
         args.electro_file, df_participants)
 
     # Read CSV file with computed metrics as Pandas DataFrame
-    df_morphometrics = read_metric_file(args.input_file)
-    # Merge df_participants['maximum_stenosis'] to df_morphometrics
-    df_morphometrics = pd.merge(df_morphometrics, df_participants[['participant_id', 'maximum_stenosis']],
-                                on='participant_id', how='outer')
-    # Change coding of 'maximum_stenosis' column (e.g., from to 'C1/C2' to '2') based on DICT_DISC_LABELS
-    df_morphometrics['level'] = df_morphometrics['maximum_stenosis'].map(DICT_DISC_LABELS)
-    # Keep only maximum level of compression (rows with maximum_stenosis == 'compression_level')
-    df_morphometrics = df_morphometrics[df_morphometrics['level'] == df_morphometrics['compression_level']]
+    df_morphometrics = read_metric_file(args.input_file, dict_exclude_subj, df_participants)
 
     file_metrics = os.path.join(path_out, 'metric_ratio_combined.csv')
     if not os.path.exists(file_metrics):

--- a/statistics/compute_stats_zurich.py
+++ b/statistics/compute_stats_zurich.py
@@ -1280,11 +1280,25 @@ def main():
 
     file_metrics = os.path.join(path_out, 'metric_ratio_combined.csv')
     if not os.path.exists(file_metrics):
-        df_morphometrics = read_MSCC(args.ifolder, dict_exclude_subj, df_participants, file_metrics)
+        df_morphometrics_mscc = read_MSCC(args.ifolder, dict_exclude_subj, df_participants, file_metrics)
     else:
-        df_morphometrics = pd.read_csv(file_metrics)
-        df_morphometrics = df_morphometrics.rename(columns={'subject': 'participant_id'})  # TODO remove when rerun
+        df_morphometrics_mscc = pd.read_csv(file_metrics)
+        df_morphometrics_mscc = df_morphometrics_mscc.rename(columns={'subject': 'participant_id'})  # TODO remove when rerun
         # TODO remove subjects with no values (in read_MSCC)
+
+    # set index of participant to have the same index
+    df_morphometrics_mscc = df_morphometrics_mscc.set_index(['participant_id'])
+    # check if index is repeated, if so, print it
+    if df_morphometrics_mscc.index.duplicated().any():
+        repeated_indices_mscc = df_morphometrics_mscc.index[df_morphometrics_mscc.index.duplicated()].tolist()
+        print(repeated_indices_mscc)
+
+    # set index of participant to have the same index
+    df_morphometrics = df_morphometrics.set_index(['participant_id'])
+    # check if index is repeated, if so, print it
+    if df_morphometrics.index.duplicated().any():
+        repeated_indices = df_morphometrics.index[df_morphometrics.index.duplicated()].tolist()
+        print(repeated_indices)
 
     # Aggregate anatomical and motion scores from the maximum level of compression and merge them with computed
     # morphometrics

--- a/statistics/compute_stats_zurich.py
+++ b/statistics/compute_stats_zurich.py
@@ -1306,20 +1306,30 @@ def main():
     # Change myelopathy for yes no column
     df_reg['myelopathy'].fillna(0, inplace=True)
     df_reg.loc[df_reg['myelopathy'] != 0, 'myelopathy'] = 1
-
+    print(df_reg.columns)
     # Drop useless columns
-    df_reg = df_reg.drop(columns=['record_id', 
-                                  'pathology', 
-                                  'date_previous_surgery', 
-                                  'surgery_date', 
-                                  'date_of_scan', 
-                                  'manufacturers_model_name', 
-                                  'manufacturer', 
+    df_reg = df_reg.drop(columns=['record_id',
+                                  'pathology',
+                                  'date_previous_surgery',
+                                  'surgery_date',
+                                  'date_of_scan',
+                                  'manufacturers_model_name',
+                                  'manufacturer',
                                   'stenosis',
-                                  'maximum_stenosis'  # TODO to change
+                                  'maximum_stenosis_y',
+                                  'maximum_stenosis_x',
+                                  'slice(I->S)',
+                                  'eccentricity_ratio_PAM50',
+                                  'diameter_RL_ratio_PAM50',
+                                  'diameter_AP_ratio_PAM50',
+                                  'area_ratio_PAM50',
+                                  'solidity_ratio_PAM50',
+                                  'eccentricity_ratio_PAM50'
+
                                   #'weight',  # missing data - TODO - try this
                                   #'height'   # missing data - TODO - try this
                                   ])
+    
     df_reg.set_index(['participant_id'], inplace=True)
     df_reg_all = df_reg.copy()
     print(df_reg.columns.values)

--- a/statistics/compute_stats_zurich.py
+++ b/statistics/compute_stats_zurich.py
@@ -184,11 +184,13 @@ def read_metric_file(file_path, dict_exclude_subj, df_participants):
     :param df_participants: Pandas DataFrame with participants.tsv file
     :return: Pandas DataFrame
     """
+    # Load CSV file
     if os.path.isfile(file_path):
         df_morphometrics = pd.read_csv(file_path)
     else:
         raise FileNotFoundError(f'{file_path} not found')
 
+    # Fetch participant_id from filename
     list_participant_id = list()
     # Loop across rows
     for index, row in df_morphometrics.iterrows():


### PR DESCRIPTION
This PR replaces the `read_MSCC` function with the `read_metric_file` function to load a single CSV metric file metrics across all subjects (`~/duke/projects/dcm-normalization/dcm-zurich_2023-08-13_persex/results/compression_metrics.csv`).


The PR can be tested using:

```
python statistics/compute_stats_zurich.py
-input-file
~/duke/projects/dcm-normalization/dcm-zurich_2023-08-13_persex/results/compression_metrics.csv
-participants-file
<PATH_TO_DATASET>/dcm-zurich/participants.tsv
-clinical-file
<PATH_TO_CLINICAL_FILE>
-electro-file
<PATH_TO_ELECTRO_FILE>
-path-out
statistics
```

---

`df_morphometrics` returned by the [`read_metric_file` function](https://github.com/sct-pipeline/dcm-metric-normalization/blob/9fe15a073831957c60dc6933792cfe0964608907/statistics/compute_stats_zurich.py#L194):
<img width="1469" alt="image" src="https://github.com/sct-pipeline/dcm-metric-normalization/assets/39456460/bc78ceb3-c1a6-4d5f-bfe2-f4365380dead">

looks to contain the same values as the CSV file aggregated by the original [`read_MSCC` function](https://github.com/sct-pipeline/dcm-metric-normalization/blob/83e572c447a3c80da2789cb5f15d4cb746db39fa/statistics/compute_stats_zurich.py#L1232):

<img width="1286" alt="image" src="https://github.com/sct-pipeline/dcm-metric-normalization/assets/39456460/1d383510-eb2c-40ef-94b1-ad6688df6c9b">


Resolves https://github.com/sct-pipeline/dcm-metric-normalization/issues/19