### PR TITLE
Clean `compute_stats_zurich` script - move functions under `utils` folder

### DIFF
--- a/statistics/compute_stats_zurich.py
+++ b/statistics/compute_stats_zurich.py
@@ -30,7 +30,7 @@ import statsmodels.api as sm
 
 from utils.utils import SmartFormatter, format_pvalue, fit_reg
 from utils.read_files import read_metric_file, read_participants_file, read_clinical_file, \
-    read_electrophysiology_anatomical_and_motion_file
+    read_electrophysiology_anatomical_and_motion_file, merge_anatomical_morphological_final_for_pred
 from utils.generate_figures import gen_chart_norm_vs_no_norm, gen_chart_corr_mjoa_mscc, gen_chart_weight_height, \
     plot_correlation_for_clinical_scores, plot_correlations_motion_and_morphometric_metrics, \
     plot_correlations_anatomical_and_morphometric_metrics
@@ -641,29 +641,6 @@ def predict_mjoa_m12_diff(df_reg, df_reg_norm):
     logger.info(f'Included repressors are: {included_norm}')
     # Fit linear regression model on included variables
     fit_reg(x_norm[included_norm], y, 'linear')
-
-
-def merge_anatomical_morphological_final_for_pred(anatomical_df, motion_df, df_morphometric):
-    """
-    Aggregate anatomical and motion scores from the maximum level of compression and merge them with computed
-    morphometrics
-    """
-    final_df = df_morphometric.copy()
-    # set index of participant to have the same index
-    final_df = final_df.set_index(['participant_id'])
-    # Loop through levels to get the corresponding motion or anatomical metric or the maximum compressed level
-    levels = np.unique(final_df['level'].to_list())
-    for level in levels:
-        # Skip C1/C2 level (2)
-        if not level == 2:
-            level_conversion = 'C' + str(int(level)-1)  # -1 to convert to zurich disc
-            # Add scores at maximum level of compression
-            final_df.loc[final_df.index[final_df['level']==level].tolist(), 'aSCOR'] = anatomical_df.loc[final_df.index[final_df['level']==level].tolist(), 'aSCOR_' + level_conversion]
-            final_df.loc[final_df.index[final_df['level']==level].tolist(), 'aMSCC'] = anatomical_df.loc[final_df.index[final_df['level']==level].tolist(), 'aMSCC_' + level_conversion + 'toC2']
-            final_df.loc[final_df.index[final_df['level']==level].tolist(), 'amp_ax_or_sag'] = motion_df.loc[final_df.index[final_df['level']==level].tolist(), level_conversion+ '_amp_ax_or_sag']
-            final_df.loc[final_df.index[final_df['level']==level].tolist(), 'disp_ax_or_sag'] = motion_df.loc[final_df.index[final_df['level']==level].tolist(), level_conversion+ '_disp_ax_or_sag']
-
-    return final_df
 
 
 # TODO:

--- a/statistics/compute_stats_zurich.py
+++ b/statistics/compute_stats_zurich.py
@@ -32,7 +32,8 @@ from utils.utils import SmartFormatter, format_pvalue, fit_reg
 from utils.read_files import read_metric_file, read_participants_file, read_clinical_file, \
     read_electrophysiology_anatomical_and_motion_file
 from utils.generate_figures import gen_chart_norm_vs_no_norm, gen_chart_corr_mjoa_mscc, generate_correlation_matrix, \
-    generate_pairplot, gen_chart_weight_height, plot_correlation_for_clinical_scores
+    generate_pairplot, gen_chart_weight_height, plot_correlation_for_clinical_scores, \
+    plot_correlations_motion_and_morphometric_metrics
 
 FNAME_LOG = 'log_stats.txt'
 # Initialize logging
@@ -693,24 +694,6 @@ def compute_correlations_anatomical_and_morphometric_metrics(final_df, path_out)
         generate_pairplot(final_df, output_pathname, logger)
 
 
-def compute_correlations_motion_and_morphometric_metrics(final_df, path_out):
-    """
-    Plot and save correlation matrix for motion data (displacement and amplitude) and morphometric metrics
-    """
-
-    # Keep only motion and morphometric metrics
-    final_df = final_df[['amp_ax_or_sag', 'disp_ax_or_sag'] + METRICS + METRICS_NORM]
-
-    # Drop rows with nan values
-    corr_df = final_df.dropna(axis=0)
-
-    output_pathname = os.path.join(path_out, 'corr_matrix_motion_and_morphometrics.png')
-    generate_correlation_matrix(corr_df, output_pathname)
-
-    output_pathname = os.path.join(path_out, 'pairplot_motion_and_morphometrics.png')
-    generate_pairplot(corr_df, output_pathname, logger)
-
-
 # TODO:
 # 0. Exclude subjects
 # 1. Calcul statistique 2 groupes (mean ± std) --> DONE
@@ -784,7 +767,7 @@ def main():
     compute_correlations_anatomical_and_morphometric_metrics(final_df, path_out)
 
     # Plot and save correlation matrix for motion data (displacement and amplitude) and morphometric metrics
-    compute_correlations_motion_and_morphometric_metrics(final_df, path_out)
+    plot_correlations_motion_and_morphometric_metrics(final_df, path_out, logger)
 
     # Change SEX for 0 and 1
     final_df = final_df.replace({"sex": {'F': 0, 'M': 1}})

--- a/statistics/compute_stats_zurich.py
+++ b/statistics/compute_stats_zurich.py
@@ -745,7 +745,7 @@ def main():
     clinical_df = read_clinical_file(args.clinical_file)
 
     # Plot correlation matrix for clinical scores
-    plot_correlation_for_clinical_scores(clinical_df, path_out)
+    plot_correlation_for_clinical_scores(clinical_df, path_out, logger)
 
     # Merge clinical scores (mJOA, ASIA, GRASSP) to participant.tsv
     df_participants = pd.merge(df_participants, clinical_df, on='record_id', how='outer', sort=True)

--- a/statistics/compute_stats_zurich.py
+++ b/statistics/compute_stats_zurich.py
@@ -20,7 +20,6 @@ import numpy as np
 import scipy.stats as stats
 import matplotlib.pyplot as plt
 from textwrap import dedent
-import seaborn as sns
 from sklearn.linear_model import LogisticRegression
 import sklearn.metrics
 from sklearn.feature_selection import RFE
@@ -32,6 +31,8 @@ import statsmodels.api as sm
 from utils.utils import SmartFormatter, format_pvalue, compute_spearmans
 from utils.read_files import read_metric_file, read_participants_file, read_clinical_file, \
     read_electrophysiology_anatomical_and_motion_file
+from utils.generate_figures import gen_chart_norm_vs_no_norm, gen_chart_corr_mjoa_mscc, generate_correlation_matrix, \
+    generate_pairplot, gen_chart_weight_height
 
 FNAME_LOG = 'log_stats.txt'
 # Initialize logging
@@ -104,90 +105,6 @@ def get_parser():
                                  - sub-1000498_T1w.nii.gz
                                  """))
     return parser
-
-
-def gen_chart_norm_vs_no_norm(df, metric, path_out=""):
-    """
-    Plot data and a linear regression model fit of normalized vs non-normalized metric
-    """
-    sns.set_style("ticks", {'axes.grid': True})
-    plt.figure()
-    fig, ax = plt.subplots()
-    #ax.set_box_aspect(1)
-    # MSCC with mJOA
-    metric_norm = metric+'_PAM50_normalized'
-    x_vals = df[metric]
-    y_vals_mscc = df[metric_norm]
-    r_mscc, p_mscc = compute_spearmans(x_vals, y_vals_mscc)
-    logger.info(f'{metric} ratio: Spearman r = {r_mscc} and p = {p_mscc}')
-    sns.regplot(x=x_vals, y=y_vals_mscc)
-    plt.ylabel((metric_norm + ' ratio'), fontsize=16)
-    plt.xlabel(metric + ' ratio', fontsize=16)
-    plt.xlim([min(x_vals) -1, max(x_vals)+1])
-    plt.tight_layout()
-    plt.text(0.03, 0.90, 'r = {}\np{}'.format(round(r_mscc, 2), format_pvalue(p_mscc, alpha=0.001, include_space=True)),
-             fontsize=10, transform=ax.transAxes,
-             bbox=dict(boxstyle='round', facecolor='white', alpha=0.95, edgecolor='lightgrey'))
-    plt.xticks(fontsize=12)
-    plt.yticks(fontsize=12)
-    # save figure
-    fname_fig = os.path.join(path_out, 'scatter_norm_no_norm_' + metric + '_mjoa.png')
-    plt.savefig(fname_fig, dpi=200, bbox_inches="tight")
-    plt.close()
-    logger.info(f'Created: {fname_fig}.\n')
-
-
-def gen_chart_corr_mjoa_mscc(df, metric, mjoa, path_out=""):
-    """
-    Plot data and a linear regression model fit of metric vs mJOA
-    """
-    sns.set_style("ticks", {'axes.grid': True})
-    plt.figure()
-    fig, ax = plt.subplots()
-    #ax.set_box_aspect(1)
-    # MSCC with mJOA
-    x_vals = df[mjoa]
-    y_vals_mscc = df[metric]
-    metric_norm = metric+'_PAM50_normalized'
-    y_vals_mscc_norm = df[metric_norm]
-
-    r_mscc, p_mscc = compute_spearmans(x_vals, y_vals_mscc)
-    r_mscc_norm, p_mscc_norm = compute_spearmans(x_vals, y_vals_mscc_norm)
-
-    logger.info(f'{metric} ratio: Spearman r = {r_mscc} and p = {p_mscc}')
-    logger.info(f'{metric_norm} ratio: Spearman r = {r_mscc_norm} and p = {p_mscc_norm}')
-
-    sns.regplot(x=x_vals, y=y_vals_mscc, label=(metric+' ratio')) #ci=None,
-    sns.regplot(x=x_vals, y=y_vals_mscc_norm, color='crimson', label=metric_norm) # ci=None,
-    plt.ylabel(metric, fontsize=16)
-    plt.xlabel('mJOA', fontsize=16)
-    plt.xlim([min(x_vals)-1, max(x_vals)+1])
-    plt.tight_layout()
-    # Insert text with corr coef and pval
-    plt.text(0.02, 0.03, 'r = {}\np{}'.format(round(r_mscc, 2), format_pvalue(p_mscc, alpha=0.001, include_space=True)),
-             fontsize=10, transform=ax.transAxes,
-             bbox=dict(boxstyle='round', facecolor='white', alpha=0.95, edgecolor='lightgrey'))
-    plt.legend(fontsize=12, bbox_to_anchor=(0.5, 1.12), loc="upper center", ncol=2, framealpha=0.95, handletextpad=0.1)
-    plt.xticks(fontsize=12)
-    plt.yticks(fontsize=12)
-    # save figure
-    fname_fig = os.path.join(path_out, 'scatter_' + metric + '_mjoa.png')
-    plt.savefig(fname_fig, dpi=200, bbox_inches="tight")
-    plt.close()
-    logger.info(f'Created: {fname_fig}.\n')
-
-    # Create pairplot to seperate with therpeutic decision 
-    plt.figure()
-    g = sns.pairplot(df, x_vars=mjoa, y_vars=metric_norm, kind='reg', hue='therapeutic_decision', palette="Set1",
-                     height=4, plot_kws={'scatter_kws': {'alpha': 0.6}, 'line_kws': {'lw': 4}})
-    g._legend.remove()
-    plt.xlim([min(x_vals)-1, max(x_vals)+1])
-    plt.legend(title='Therapeutic decision', loc='lower left', labels=['conservative', 'operative'])
-    plt.tight_layout()
-    fname_fig = os.path.join(path_out, 'pairwise_plot_' + metric_norm + '.png')
-    plt.savefig(fname_fig)
-    plt.close()
-    logger.info(f'Created: {fname_fig}.\n')
 
 
 def compute_mean_std(df, path_out):
@@ -741,52 +658,6 @@ def predict_mjoa_m12_diff(df_reg, df_reg_norm):
     fit_reg(x_norm[included_norm], y, 'linear')
 
 
-def compare_mjoa_between_therapeutic_decision(df_reg, path_out):
-    """
-    Compare mJOA change between subjects with therapeutic_decision == 0 and subjects with therapeutic_decision == 1.
-    """
-    # Get difference between mjoa_6m and mjoa
-    df_reg['mjoa_6m_diff'] = df_reg['mjoa'] - df_reg['mjoa_6m']
-    df_6m = df_reg.dropna(axis=0, subset=['mjoa_6m_diff'])
-    print(df_6m[['therapeutic_decision', 'mjoa_6m_diff']].groupby(['therapeutic_decision']).agg(['mean', 'std']))
-
-    # Get difference between mjoa_12m and mjoa
-    df_reg['mjoa_12m_diff'] = df_reg['mjoa'] - df_reg['mjoa_12m']
-    df_12m = df_reg.dropna(axis=0, subset=['mjoa_12m_diff'])
-
-    print(df_12m[['therapeutic_decision', 'mjoa_12m_diff']].groupby(['therapeutic_decision']).agg(['mean', 'std']))
-
-    # Create DataFrame with three columns: therapeutic_decision, mjoa_diff, and mjoa_6m_12m (6m or 12m) for easy
-    # plotting using sns hue option
-    df_6m_temp = pd.DataFrame(columns=['therapeutic_decision', 'mjoa_diff', 'mjoa_6m_12m'])
-    df_6m_temp['therapeutic_decision'] = df_6m['therapeutic_decision']
-    df_6m_temp['mjoa_diff'] = df_6m['mjoa_6m_diff']
-    df_6m_temp['mjoa_6m_12m'] = '6 months'
-    df_12_temp = pd.DataFrame(columns=['therapeutic_decision', 'mjoa_diff', 'mjoa_6m_12m'])
-    df_12_temp['therapeutic_decision'] = df_12m['therapeutic_decision']
-    df_12_temp['mjoa_diff'] = df_12m['mjoa_12m_diff']
-    df_12_temp['mjoa_6m_12m'] = '12 months'
-    df_final_temp = pd.concat([df_6m_temp, df_12_temp])
-
-    fig, ax = plt.subplots(figsize=(6, 6))
-    # Plot scatter plot and boxplot
-    sns.stripplot(x='mjoa_6m_12m', y='mjoa_diff', hue='therapeutic_decision', data=df_final_temp, ax=ax, dodge=True,
-                  edgecolor='black', linewidth=1, legend=False)
-    sns.boxplot(x='mjoa_6m_12m', y='mjoa_diff', hue='therapeutic_decision', data=df_final_temp, ax=ax, dodge=True,
-                showfliers = False)
-    # Change x axis label
-    ax.set_xlabel('')
-    # Change y axis label
-    ax.set_ylabel('mJOA difference', fontsize=14)
-    # Increase tick label size
-    ax.tick_params(axis='both', which='major', labelsize=14)
-    # save figure
-    fname_fig = os.path.join(path_out, 'boxplot_therapeutic_decision_mjoa.png')
-    plt.savefig(fname_fig, dpi=200, bbox_inches="tight")
-    plt.close()
-    logger.info(f'Created: {fname_fig}.\n')
-
-
 def merge_anatomical_morphological_final_for_pred(anatomical_df, motion_df, df_morphometric):
     """
     Aggregate anatomical and motion scores from the maximum level of compression and merge them with computed
@@ -835,7 +706,7 @@ def compute_correlations_anatomical_and_morphometric_metrics(final_df, path_out)
         generate_correlation_matrix(final_df, output_pathname)
 
         output_pathname = os.path.join(path_out, 'pairplot_anatomical_and_morphometrics_' + key + '.png')
-        generate_pairplot(final_df, output_pathname)
+        generate_pairplot(final_df, output_pathname, logger)
 
 
 def compute_correlations_motion_and_morphometric_metrics(final_df, path_out):
@@ -853,7 +724,7 @@ def compute_correlations_motion_and_morphometric_metrics(final_df, path_out):
     generate_correlation_matrix(corr_df, output_pathname)
 
     output_pathname = os.path.join(path_out, 'pairplot_motion_and_morphometrics.png')
-    generate_pairplot(corr_df, output_pathname)
+    generate_pairplot(corr_df, output_pathname, logger)
 
 
 def plot_correlation_for_clinical_scores(clinical_df, path_out):
@@ -876,64 +747,7 @@ def plot_correlation_for_clinical_scores(clinical_df, path_out):
     generate_correlation_matrix(corr_df, output_pathname)
 
     output_pathname = os.path.join(path_out, 'pairplot_clinical_scores.png')
-    generate_pairplot(corr_df, output_pathname)
-
-
-def generate_correlation_matrix(df, output_pathname):
-    """
-    Plot and save correlation matrix as .csv and .png
-    df: dataframe to use
-    output_pathname: path to save the correlation matrix
-    """
-
-    sns.set(font_scale=1)
-    corr_matrix = df.corr()
-    corr_matrix.to_csv(output_pathname.replace('.png', '.csv'))
-    corr_matrix = corr_matrix.round(2)
-    fig, ax = plt.subplots(figsize=(10, 10))
-    sns.heatmap(corr_matrix, annot=True, linewidths=.5, ax=ax)
-    # Put level and number of subjects to the title
-    ax.set_title('Number of subjects = {}'.format(len(df)))
-    plt.savefig(output_pathname, dpi=300, bbox_inches='tight')
-    plt.close()
-    print('Correlation matrix saved to: {}'.format(output_pathname))
-
-
-def generate_pairplot(df, output_pathname):
-    """"
-    Plot and save pairplot
-    df: dataframe to use
-    path_out: path to save the pairplot
-    """
-    print('Generating pairplot...(it may take a while)...')
-    sns.set(font_scale=1.5)
-    sns.pairplot(df, kind="reg", diag_kws={'color': 'orange'})
-    plt.savefig(output_pathname, dpi=300, bbox_inches='tight')
-    plt.close()
-    print('Pairplot saved to: {}'.format(output_pathname))
-
-
-def gen_chart_weight_height(df_reg, path_out):
-    """
-    Plot weight and height relationship per sex
-    """
-
-    # Drop nan for weight and height
-    df_reg.dropna(axis=0, subset=['weight', 'height'], inplace=True)
-    print(f'Number of subjects after dropping nan for weight and height: {len(df_reg)}')
-
-    sns.regplot(x='weight', y='height', data=df_reg[df_reg['sex'] == 1], label='Male', color='blue')
-    sns.regplot(x='weight', y='height', data=df_reg[df_reg['sex'] == 0], label='Female', color='red')
-    plt.legend()
-    # x axis label
-    plt.xlabel('Weight (kg)')
-    # y axis label
-    plt.ylabel('Height (m)')
-    # save figure
-    fname_fig = os.path.join(path_out, 'regplot_weight_height_relationship_persex.png')
-    plt.savefig(fname_fig, dpi=200, bbox_inches="tight")
-    plt.close()
-    logger.info(f'Created: {fname_fig}.\n')
+    generate_pairplot(corr_df, output_pathname, logger)
 
 
 # TODO:
@@ -1029,10 +843,10 @@ def main():
     # Loop across metrics
     for metric in METRICS:
         # Create charts mJOA vs individual metrics (both normalized and not normalized)
-        gen_chart_corr_mjoa_mscc(final_df, metric, 'total_mjoa', path_out)
+        gen_chart_corr_mjoa_mscc(final_df, metric, 'total_mjoa', path_out, logger)
         # Plot scatter plot normalized vs not normalized
         logger.info(f'Correlation {metric} norm vs no norm')
-        gen_chart_norm_vs_no_norm(final_df, metric, path_out)
+        gen_chart_norm_vs_no_norm(final_df, metric, path_out, logger)
     
     # Create sub-dataset to compute logistic regression
     df_reg = final_df.copy()
@@ -1072,7 +886,7 @@ def main():
     df_reg_norm.drop(inplace=True, columns=METRICS)
 
     # Create sns.regplot between sex and weight
-    gen_chart_weight_height(df_reg, path_out)
+    gen_chart_weight_height(df_reg, path_out, logger)
 
     # get mean ± std of predictors
     logger.info('Computing mean ± std')

--- a/statistics/compute_stats_zurich.py
+++ b/statistics/compute_stats_zurich.py
@@ -28,7 +28,7 @@ from statsmodels.stats.outliers_influence import variance_inflation_factor
 from sklearn.metrics import auc
 import statsmodels.api as sm
 
-from utils.utils import SmartFormatter, format_pvalue, compute_spearmans
+from utils.utils import SmartFormatter, format_pvalue, compute_spearmans, fit_reg
 from utils.read_files import read_metric_file, read_participants_file, read_clinical_file, \
     read_electrophysiology_anatomical_and_motion_file
 from utils.generate_figures import gen_chart_norm_vs_no_norm, gen_chart_corr_mjoa_mscc, generate_correlation_matrix, \
@@ -166,19 +166,7 @@ def compute_mean_std(df, path_out):
     logger.info(f'Levels (%): \n{ratio2}')
 
 
-def fit_reg(X, y, method):
-    """
-    Fit either linear regression (the dependent variable is non-binary) or logistic regression (the dependent variable
-    is binary) and print summary.
-    Args:
-        method: 'linear' or 'logistic'
-    """
-    if method == 'linear':
-        logit_model = sm.OLS(y, X)      # Ordinary Least Squares Regression
-    elif method == 'logistic':
-        logit_model = sm.Logit(y, X)    # Logistic Regression
-    result = logit_model.fit()
-    print(result.summary2())
+
 
 
 def compute_stepwise(y, x, threshold_in, threshold_out, method):

--- a/statistics/compute_stats_zurich.py
+++ b/statistics/compute_stats_zurich.py
@@ -28,7 +28,7 @@ from statsmodels.stats.outliers_influence import variance_inflation_factor
 from sklearn.metrics import auc
 import statsmodels.api as sm
 
-from utils.utils import SmartFormatter, format_pvalue, compute_spearmans, fit_reg
+from utils.utils import SmartFormatter, format_pvalue, fit_reg
 from utils.read_files import read_metric_file, read_participants_file, read_clinical_file, \
     read_electrophysiology_anatomical_and_motion_file
 from utils.generate_figures import gen_chart_norm_vs_no_norm, gen_chart_corr_mjoa_mscc, generate_correlation_matrix, \

--- a/statistics/compute_stats_zurich.py
+++ b/statistics/compute_stats_zurich.py
@@ -30,7 +30,7 @@ from statsmodels.stats.outliers_influence import variance_inflation_factor
 from sklearn.metrics import auc
 import statsmodels.api as sm
 
-from utils import SmartFormatter, read_metric_file, read_participants_file
+from utils import SmartFormatter, read_metric_file, read_participants_file, read_clinical_file
 
 FNAME_LOG = 'log_stats.txt'
 # Initialize logging
@@ -103,56 +103,6 @@ def get_parser():
                                  - sub-1000498_T1w.nii.gz
                                  """))
     return parser
-
-
-def read_clinical_file(file_path):
-    """
-    Read file with clinical scores (mJOA, ASIA, GRASSP) and return Pandas DataFrame
-    :param file_path: path to excel file
-    :return: Pandas DataFrame
-    """
-    if os.path.isfile(file_path):
-        print('Reading: {}'.format(file_path))
-        clinical_df = pd.read_excel(file_path)
-    else:
-        raise FileNotFoundError(f'{file_path} not found')
-    # mJOA
-    mjoa = 'total_mjoa'         # baseline
-    mjoa_6m = 'total_mjoa.1'    # 6 months
-    mjoa_12m = 'total_mjoa.2'   # 12 months
-
-    # mJOA subscores
-    motor_dysfunction_UE_bl = 'motor_dysfunction_UE_bl'         # baseline
-    motor_dysfunction_LE_bl = 'motor_dysfunction_LE_bl'         # baseline
-    sensory_dysfunction_LE_bl = 'sensory_dysfunction_LE_bl'     # baseline
-    sphincter_dysfunction_bl = 'sphincter_dysfunction_bl'       # baseline
-
-    # ASIA/GRASSP - lt_cervical_tot
-    lt_cervical_tot = 'lt_cervical_tot'         # baseline
-    lt_cervical_tot_6m = 'lt_cervical_tot.1'    # 6 months
-    lt_cervical_tot_12m = 'lt_cervical_tot.2'   # 12 months
-    # ASIA/GRASSP - pp_cervical_tot
-    pp_cervical_tot = 'pp_cervical_tot'        # baseline
-    pp_cervical_tot_6m = 'pp_cervical_tot.1'   # 6 months
-    pp_cervical_tot_12m = 'pp_cervical_tot.2'  # 12 months
-    # ASIA/GRASSP - total_dorsal
-    total_dorsal = 'total_dorsal'        # baseline
-    total_dorsal_6m = 'total_dorsal.1'   # 6 months
-    total_dorsal_12m = 'total_dorsal.2'  # 12 months
-
-    # Read columns of interest from clinical file
-    clinical_df = clinical_df[['record_id', mjoa, mjoa_6m, mjoa_12m,
-                               motor_dysfunction_UE_bl, motor_dysfunction_LE_bl, sensory_dysfunction_LE_bl, sphincter_dysfunction_bl,
-                               lt_cervical_tot, lt_cervical_tot_6m, lt_cervical_tot_12m,
-                               pp_cervical_tot, pp_cervical_tot_6m, pp_cervical_tot_12m,
-                               total_dorsal, total_dorsal_6m, total_dorsal_12m]]
-
-    # Rename .1 to 6m and .2 to 12m
-    clinical_df.columns = clinical_df.columns.str.replace('.1', '_6m')
-    clinical_df.columns = clinical_df.columns.str.replace('.2', '_12m')
-
-    #print(clinical_df)
-    return clinical_df
 
 
 def read_electrophysiology_anatomical_and_motion_file(file_path, df_participants):

--- a/statistics/compute_stats_zurich.py
+++ b/statistics/compute_stats_zurich.py
@@ -30,7 +30,7 @@ from statsmodels.stats.outliers_influence import variance_inflation_factor
 from sklearn.metrics import auc
 import statsmodels.api as sm
 
-from utils import SmartFormatter, read_metric_file
+from utils import SmartFormatter, read_metric_file, read_participants_file
 
 FNAME_LOG = 'log_stats.txt'
 # Initialize logging
@@ -103,21 +103,6 @@ def get_parser():
                                  - sub-1000498_T1w.nii.gz
                                  """))
     return parser
-
-
-def read_participants_file(file_path):
-    """
-    Read participants.tsv file and return Pandas DataFrame
-    :param file_path: path to participants.tsv file
-    :return: Pandas DataFrame
-    """
-    if os.path.isfile(file_path):
-        participants_pd = pd.read_csv(file_path, sep='\t')
-    else:
-        raise FileNotFoundError(f'{file_path} not found')
-
-    # print(df_participants)
-    return participants_pd
 
 
 def read_clinical_file(file_path):

--- a/statistics/compute_stats_zurich.py
+++ b/statistics/compute_stats_zurich.py
@@ -30,7 +30,7 @@ import statsmodels.api as sm
 
 from utils.utils import SmartFormatter, format_pvalue, fit_reg
 from utils.read_files import read_metric_file, read_participants_file, read_clinical_file, \
-    read_electrophysiology_anatomical_and_motion_file, merge_anatomical_morphological_final_for_pred
+    read_electrophysiology_file, read_anatomical_file, read_motion_file, merge_anatomical_morphological_final_for_pred
 from utils.generate_figures import gen_chart_norm_vs_no_norm, gen_chart_corr_mjoa_mscc, gen_chart_weight_height, \
     plot_correlation_for_clinical_scores, plot_correlations_motion_and_morphometric_metrics, \
     plot_correlations_anatomical_and_morphometric_metrics
@@ -72,22 +72,33 @@ def get_parser():
         '-input-file',
         required=True,
         metavar='<file_path>',
-        help="Path to csv file with computed morphometric metrics")
+        help="Path to the CSV file with computed morphometric metrics")
     parser.add_argument(
         '-participants-file',
         required=True,
         metavar='<file_path>',
-        help="dcm-zurich participants.tsv file")
+        help="Path to the dcm-zurich participants.tsv file")
     parser.add_argument(
         '-clinical-file',
         required=True,
         metavar='<file_path>',
-        help="excel file with clinical data")
+        help="Path to the Excel file with clinical scores such as mJOA, Nurick, ASIA. Example: clinical_scores.xlsx")
+    parser.add_argument(
+        '-anatomical-file',
+        required=True,
+        metavar='<file_path>',
+        help="Path to the Excel file with anatomical data (aSCOR and aMSCC). Example: anatomical_data.xlsx")
     parser.add_argument(
         '-electro-file',
         required=True,
         metavar='<file_path>',
-        help="excel file with electrophysiology and anatomical data")
+        help="Path to the Excel file with electrophysiology such as SEP, CHEPS. Example: "
+             "electrophysiological_measurements.xlsx")
+    parser.add_argument(
+        '-motion-file',
+        required=True,
+        metavar='<file_path>',
+        help="Path to the Excel file with motion data (amplitude and displacement). Example: motion_data.xlsx")
     parser.add_argument(
         '-path-out',
         required=True,
@@ -700,8 +711,9 @@ def main():
     df_participants = pd.merge(df_participants, clinical_df, on='record_id', how='outer', sort=True)
 
     # Read electrophysiology, anatomical, and motion data
-    anatomical_df, motion_df, electrophysiology_df = read_electrophysiology_anatomical_and_motion_file(
-        args.electro_file, df_participants)
+    electrophysiology_df = read_electrophysiology_file(args.electro_file, df_participants)
+    anatomical_df = read_anatomical_file(args.anatomical_file, df_participants)
+    motion_df = read_motion_file(args.motion_file, df_participants)
 
     # Read CSV file with computed metrics as Pandas DataFrame
     df_morphometrics = read_metric_file(args.input_file, dict_exclude_subj, df_participants)

--- a/statistics/compute_stats_zurich.py
+++ b/statistics/compute_stats_zurich.py
@@ -29,8 +29,9 @@ from statsmodels.stats.outliers_influence import variance_inflation_factor
 from sklearn.metrics import auc
 import statsmodels.api as sm
 
-from utils import SmartFormatter, read_metric_file, read_participants_file, read_clinical_file, \
-    read_electrophysiology_anatomical_and_motion_file, format_pvalue, compute_spearmans
+from utils.utils import SmartFormatter, format_pvalue, compute_spearmans
+from utils.read_files import read_metric_file, read_participants_file, read_clinical_file, \
+    read_electrophysiology_anatomical_and_motion_file
 
 FNAME_LOG = 'log_stats.txt'
 # Initialize logging

--- a/statistics/compute_stats_zurich.py
+++ b/statistics/compute_stats_zurich.py
@@ -264,7 +264,7 @@ def fit_model_metrics(X, y, regressors=None, path_out=None, filename='Log_ROC'):
     if regressors:
         X = X[regressors]
 
-    fig, ax = plt.subplots(figsize=(6, 6))
+    fig, ax = plt.subplots(figsize=(10, 6))
     #kf = StratifiedKFold(n_splits=10, shuffle=True)
     kf = RepeatedStratifiedKFold(n_splits=10, n_repeats=100)
     scores = []
@@ -443,11 +443,11 @@ def predict_theurapeutic_decision(df_reg, df_reg_all, df_reg_norm, path_out):
     y_z_score = df_reg_all['therapeutic_decision'].astype(int)
     df_z_score = get_z_score(df_reg_all)
     # Do composite z_score for no norm between area, diameter_AP, diameter_RL
-    df_z_score['composite_zscore'] = df_z_score[['area_ratio_zscore', 'diameter_AP_zscore', 'diameter_RL_zscore']].mean(
+    df_z_score['composite_zscore'] = df_z_score[['area_ratio_zscore', 'diameter_AP_ratio_zscore', 'diameter_RL_ratio_zscore']].mean(
         axis=1)
     # Do composite z_score for norm between area, diameter_AP, diameter_RL TODO: maybe remove diameter RL?
     df_z_score['composite_zscore_norm'] = df_z_score[
-        ['area_ratio_PAM50_normalized_zscore', 'diameter_AP_PAM50_normalized_zscore', 'diameter_RL_PAM50_normalized_zscore']].mean(axis=1)
+        ['area_ratio_PAM50_normalized_zscore', 'diameter_AP_ratio_PAM50_normalized_zscore', 'diameter_RL_ratio_PAM50_normalized_zscore']].mean(axis=1)
     # mean_zscore = df_z_score.groupby('therapeutic_decision').agg([np.mean])
     # print(mean_zscore['diameter_AP_zscore'])
     mean_zscore = df_z_score.groupby('therapeutic_decision').agg([np.mean])
@@ -712,6 +712,7 @@ def main():
 
     # Read electrophysiology, anatomical, and motion data
     electrophysiology_df = read_electrophysiology_file(args.electro_file, df_participants)
+    print(electrophysiology_df)
     anatomical_df = read_anatomical_file(args.anatomical_file, df_participants)
     motion_df = read_motion_file(args.motion_file, df_participants)
 
@@ -777,7 +778,9 @@ def main():
                                   'diameter_AP_ratio_PAM50',
                                   'area_ratio_PAM50',
                                   'solidity_ratio_PAM50',
-                                  'eccentricity_ratio_PAM50'
+                                  'eccentricity_ratio_PAM50',
+                                  'amp_ax_or_sag',
+                                  'disp_ax_or_sag'
 
                                   #'weight',  # missing data - TODO - try this
                                   #'height'   # missing data - TODO - try this

--- a/statistics/compute_stats_zurich.py
+++ b/statistics/compute_stats_zurich.py
@@ -31,9 +31,9 @@ import statsmodels.api as sm
 from utils.utils import SmartFormatter, format_pvalue, fit_reg
 from utils.read_files import read_metric_file, read_participants_file, read_clinical_file, \
     read_electrophysiology_anatomical_and_motion_file
-from utils.generate_figures import gen_chart_norm_vs_no_norm, gen_chart_corr_mjoa_mscc, generate_correlation_matrix, \
-    generate_pairplot, gen_chart_weight_height, plot_correlation_for_clinical_scores, \
-    plot_correlations_motion_and_morphometric_metrics, plot_correlations_anatomical_and_morphometric_metrics
+from utils.generate_figures import gen_chart_norm_vs_no_norm, gen_chart_corr_mjoa_mscc, gen_chart_weight_height, \
+    plot_correlation_for_clinical_scores, plot_correlations_motion_and_morphometric_metrics, \
+    plot_correlations_anatomical_and_morphometric_metrics
 
 FNAME_LOG = 'log_stats.txt'
 # Initialize logging

--- a/statistics/compute_stats_zurich.py
+++ b/statistics/compute_stats_zurich.py
@@ -10,7 +10,6 @@
 # Author: Sandrine Bédard, Jan Valosek
 
 import os
-import re
 import argparse
 import pandas as pd
 import logging
@@ -31,7 +30,7 @@ from statsmodels.stats.outliers_influence import variance_inflation_factor
 from sklearn.metrics import auc
 import statsmodels.api as sm
 
-from utils import SmartFormatter
+from utils import SmartFormatter, read_metric_file
 
 FNAME_LOG = 'log_stats.txt'
 # Initialize logging
@@ -104,74 +103,6 @@ def get_parser():
                                  - sub-1000498_T1w.nii.gz
                                  """))
     return parser
-
-
-def read_metric_file(file_path, dict_exclude_subj, df_participants):
-    """
-    Read CSV file with computed metrics and return Pandas DataFrame
-    :param file_path: path to the CSV file with computed metrics
-    :param dict_exclude_subj: list with subjects to exclude
-    :param df_participants: Pandas DataFrame with participants.tsv file
-    :return: Pandas DataFrame
-    """
-    # Load CSV file
-    if os.path.isfile(file_path):
-        df_morphometrics = pd.read_csv(file_path)
-    else:
-        raise FileNotFoundError(f'{file_path} not found')
-
-    # Fetch participant_id from filename
-    list_participant_id = list()
-    # Loop across rows
-    for index, row in df_morphometrics.iterrows():
-        participant_id = fetch_participant_id(row['filename'])
-        list_participant_id.append(participant_id)
-    # Insert list of subIDs into pandas DF
-    df_morphometrics.insert(1, "participant_id", list_participant_id)
-    # Delete column 'filename'
-    df_morphometrics.drop('filename', axis=1, inplace=True)
-
-    # Merge df_participants['maximum_stenosis'] to df_morphometrics
-    df_morphometrics = pd.merge(df_morphometrics, df_participants[['participant_id', 'maximum_stenosis']],
-                                on='participant_id', how='left')
-    # Change coding of 'maximum_stenosis' column (e.g., from to 'C1/C2' to '2') based on DICT_DISC_LABELS
-    df_morphometrics['level'] = df_morphometrics['maximum_stenosis'].map(DICT_DISC_LABELS)
-    # NOTE: after this merge, df_morphometrics has the following columns:
-    #   'compression_level' - obtained from sct_compute_compression function based on vert labeling, example 5
-    #   'maximum_stenosis' - obtained from participants.tsv file, example 'C5/C6'
-    #   'level' - obtained from participants.tsv file and recoded using DICT_DISC_LABELS, example 6
-
-    # Subjects might have multiple levels of compression --> keep only the maximally compressed level (MCL)
-    # Get unique list of subjects
-    unique_subjects = df_morphometrics['participant_id'].unique().tolist()
-    # Loop across subjects
-    for sub in unique_subjects:
-        # First, get the maximally compressed level
-        max_level = df_participants.loc[df_participants['participant_id'] == sub, 'maximum_stenosis'].to_list()[0]
-        # Second, get all the compressed levels
-        all_compressed_levels = df_participants.loc[df_participants['participant_id'] == sub, 'stenosis'].to_list()[
-            0].split(', ')
-        # Third, get the index of the maximally compressed level
-        idx_max = all_compressed_levels.index(max_level)
-
-        # Get all rows of the subject from df_motphometrics
-        # Note: we are resetting the index to be able to use the index as a list, also we use the drop parameter to
-        # avoid the old index being added as a column
-        df_sub = df_morphometrics.loc[df_morphometrics['participant_id'] == sub].reset_index(drop=True)
-
-        # Check if the maximally compressed level is in the axial FOV (i.e., in the df_sub)
-        if idx_max not in df_sub.index.to_list():
-            print(f'Maximum level of compression {max_level} is not in axial FOV, excluding {sub}')
-            df_morphometrics.drop(df_morphometrics.loc[df_morphometrics['participant_id'] == sub].index, inplace=True)
-            dict_exclude_subj.append(sub)
-        # If the maximally compressed level is in the axial FOV, keep only this row
-        else:
-            # Get 'slice(I->S)' of df_sub with the maximally compressed level
-            slice_max = df_sub.loc[idx_max, 'slice(I->S)']
-            df_morphometrics = df_morphometrics.drop(df_morphometrics.loc[(df_morphometrics['participant_id'] == sub) &
-                                                          (df_morphometrics['slice(I->S)'] != slice_max)].index)
-
-    return df_morphometrics
 
 
 def read_participants_file(file_path):
@@ -1168,18 +1099,6 @@ def gen_chart_weight_height(df_reg, path_out):
     plt.savefig(fname_fig, dpi=200, bbox_inches="tight")
     plt.close()
     logger.info(f'Created: {fname_fig}.\n')
-
-
-def fetch_participant_id(filename):
-    """
-    Get participant ID from the input BIDS-compatible filename
-    :param filename_path: input nifti filename (e.g., sub-001_ses-01_T1w.nii.gz)
-    :return: participant_id: subject ID (e.g., sub-001)
-    """
-    participant_id = re.search('sub-(.*?)[_/]', filename)  # [_/] slash or underscore
-    participant_id = participant_id.group(0)[:-1] if participant_id else ""  # [:-1] removes the last underscore or slash
-
-    return participant_id
 
 
 # TODO:

--- a/statistics/compute_stats_zurich.py
+++ b/statistics/compute_stats_zurich.py
@@ -17,7 +17,6 @@ import math
 import sys
 import yaml
 import numpy as np
-from scipy.stats import spearmanr, pearsonr
 import scipy.stats as stats
 import matplotlib.pyplot as plt
 from textwrap import dedent
@@ -31,7 +30,7 @@ from sklearn.metrics import auc
 import statsmodels.api as sm
 
 from utils import SmartFormatter, read_metric_file, read_participants_file, read_clinical_file, \
-    read_electrophysiology_anatomical_and_motion_file, format_pvalue
+    read_electrophysiology_anatomical_and_motion_file, format_pvalue, compute_spearmans
 
 FNAME_LOG = 'log_stats.txt'
 # Initialize logging
@@ -104,12 +103,6 @@ def get_parser():
                                  - sub-1000498_T1w.nii.gz
                                  """))
     return parser
-
-
-def compute_spearmans(a,b):
-    a = np.array(a)
-    b = np.array(b)
-    return spearmanr(a,b)
 
 
 def gen_chart_norm_vs_no_norm(df, metric, path_out=""):

--- a/statistics/compute_stats_zurich.py
+++ b/statistics/compute_stats_zurich.py
@@ -31,6 +31,8 @@ from statsmodels.stats.outliers_influence import variance_inflation_factor
 from sklearn.metrics import auc
 import statsmodels.api as sm
 
+from utils import SmartFormatter
+
 FNAME_LOG = 'log_stats.txt'
 # Initialize logging
 logger = logging.getLogger(__name__)

--- a/statistics/compute_stats_zurich.py
+++ b/statistics/compute_stats_zurich.py
@@ -31,7 +31,7 @@ from sklearn.metrics import auc
 import statsmodels.api as sm
 
 from utils import SmartFormatter, read_metric_file, read_participants_file, read_clinical_file, \
-    read_electrophysiology_anatomical_and_motion_file
+    read_electrophysiology_anatomical_and_motion_file, format_pvalue
 
 FNAME_LOG = 'log_stats.txt'
 # Initialize logging
@@ -332,35 +332,6 @@ def compute_stepwise(y, x, threshold_in, threshold_out, method):
             break
 
     return included
-
-
-def format_pvalue(p_value, alpha=0.001, decimal_places=3, include_space=False, include_equal=True):
-    """
-    Format p-value.
-    If the p-value is lower than alpha, format it to "<0.001", otherwise, round it to three decimals
-    :param p_value: input p-value as a float
-    :param alpha: significance level
-    :param decimal_places: number of decimal places the p-value will be rounded
-    :param include_space: include space or not (e.g., ' = 0.06')
-    :param include_equal: include equal sign ('=') to the p-value (e.g., '=0.06') or not (e.g., '0.06')
-    :return: p_value: the formatted p-value (e.g., '<0.05') as a str
-    """
-    if include_space:
-        space = ' '
-    else:
-        space = ''
-
-    # If the p-value is lower than alpha, return '<alpha' (e.g., <0.001)
-    if p_value < alpha:
-        p_value = space + "<" + space + str(alpha)
-    # If the p-value is greater than alpha, round it number of decimals specified by decimal_places
-    else:
-        if include_equal:
-            p_value = space + '=' + space + str(round(p_value, decimal_places))
-        else:
-            p_value = space + str(round(p_value, decimal_places))
-
-    return p_value
 
 
 def compute_test_myelopathy(df):

--- a/statistics/compute_stats_zurich.py
+++ b/statistics/compute_stats_zurich.py
@@ -157,16 +157,12 @@ def compute_mean_std(df, path_out):
     logger.info(f'Conservative:{pct_of_no_sub} %; Operative: {(100-pct_of_no_sub)} %')
 
     # Maximum level of compression
-    ratio =  df['level'].value_counts(normalize=True)*100
+    ratio = df['level'].value_counts(normalize=True)*100
     logger.info(f'Levels (%): \n{ratio}')
 
-
     # Maximum level of compression seperated for therapeutic decision
-    ratio2 =  df.groupby('therapeutic_decision')['level'].value_counts(normalize=True)*100
+    ratio2 = df.groupby('therapeutic_decision')['level'].value_counts(normalize=True)*100
     logger.info(f'Levels (%): \n{ratio2}')
-
-
-
 
 
 def compute_stepwise(y, x, threshold_in, threshold_out, method):

--- a/statistics/compute_stats_zurich.py
+++ b/statistics/compute_stats_zurich.py
@@ -106,19 +106,6 @@ def get_parser():
     return parser
 
 
-def csv2dataFrame(filename):
-    """
-    Loads a .csv file and builds a pandas dataFrame of the data
-    Args:
-        filename (str): filename of the .csv file
-    Returns:
-        data (pd.dataFrame): pandas dataframe of the .csv file's data
-    """
-    #print(filename)
-    data = pd.read_csv(filename, encoding='utf-8')
-    return data
-
-
 def read_metric_file(file_path, dict_exclude_subj, df_participants):
     """
     Read CSV file with computed metrics and return Pandas DataFrame

--- a/statistics/compute_stats_zurich.py
+++ b/statistics/compute_stats_zurich.py
@@ -33,7 +33,7 @@ from utils.read_files import read_metric_file, read_participants_file, read_clin
     read_electrophysiology_anatomical_and_motion_file
 from utils.generate_figures import gen_chart_norm_vs_no_norm, gen_chart_corr_mjoa_mscc, generate_correlation_matrix, \
     generate_pairplot, gen_chart_weight_height, plot_correlation_for_clinical_scores, \
-    plot_correlations_motion_and_morphometric_metrics
+    plot_correlations_motion_and_morphometric_metrics, plot_correlations_anatomical_and_morphometric_metrics
 
 FNAME_LOG = 'log_stats.txt'
 # Initialize logging
@@ -666,34 +666,6 @@ def merge_anatomical_morphological_final_for_pred(anatomical_df, motion_df, df_m
     return final_df
 
 
-def compute_correlations_anatomical_and_morphometric_metrics(final_df, path_out):
-    """
-    Plot and save correlation matrix and pairplot for anatomical (aSCOR and aMSCC) and morphometric metrics
-    """
-
-    # Keep only anatomical and morphometric metrics
-    metrics_dict = {'all_metrics': METRICS + METRICS_NORM + ['aSCOR', 'aMSCC'],
-                    'area_ratio': ['area_ratio', 'area_ratio_PAM50_normalized', 'aSCOR', 'aMSCC']}
-
-    # Either all metrics or only area
-    for key, value in metrics_dict.items():
-        final_df = final_df[value]
-
-        # Make 'aSCOR' and 'aMSCC' first and second columns
-        cols = final_df.columns.tolist()
-        cols = cols[-2:] + cols[:-2]
-        final_df = final_df[cols]
-
-        # Drop rows with nan values
-        final_df = final_df.dropna(axis=0)
-
-        output_pathname = os.path.join(path_out, 'corr_matrix_anatomical_and_morphometrics_' + key + '.png')
-        generate_correlation_matrix(final_df, output_pathname)
-
-        output_pathname = os.path.join(path_out, 'pairplot_anatomical_and_morphometrics_' + key + '.png')
-        generate_pairplot(final_df, output_pathname, logger)
-
-
 # TODO:
 # 0. Exclude subjects
 # 1. Calcul statistique 2 groupes (mean ± std) --> DONE
@@ -764,7 +736,7 @@ def main():
     final_df = pd.merge(df_participants, df_clinical_all, on='participant_id', how='outer', sort=True)
 
     # Plot and save correlation matrix and pairplot for anatomical (aSCOR and aMSCC) and morphometric metrics
-    compute_correlations_anatomical_and_morphometric_metrics(final_df, path_out)
+    plot_correlations_anatomical_and_morphometric_metrics(final_df, path_out, logger)
 
     # Plot and save correlation matrix for motion data (displacement and amplitude) and morphometric metrics
     plot_correlations_motion_and_morphometric_metrics(final_df, path_out, logger)

--- a/statistics/compute_stats_zurich.py
+++ b/statistics/compute_stats_zurich.py
@@ -61,15 +61,6 @@ DICT_DISC_LABELS = {
 }
 
 
-class SmartFormatter(argparse.HelpFormatter):
-
-    def _split_lines(self, text, width):
-        if text.startswith('R|'):
-            return text[2:].splitlines()
-        # this is the RawTextHelpFormatter._split_lines
-        return argparse.HelpFormatter._split_lines(self, text, width)
-
-
 def get_parser():
     parser = argparse.ArgumentParser(
         description="Computes statistics and generates figures for the dcm-zurich dataset.",

--- a/statistics/compute_stats_zurich.py
+++ b/statistics/compute_stats_zurich.py
@@ -32,7 +32,7 @@ from utils.utils import SmartFormatter, format_pvalue, fit_reg
 from utils.read_files import read_metric_file, read_participants_file, read_clinical_file, \
     read_electrophysiology_anatomical_and_motion_file
 from utils.generate_figures import gen_chart_norm_vs_no_norm, gen_chart_corr_mjoa_mscc, generate_correlation_matrix, \
-    generate_pairplot, gen_chart_weight_height
+    generate_pairplot, gen_chart_weight_height, plot_correlation_for_clinical_scores
 
 FNAME_LOG = 'log_stats.txt'
 # Initialize logging
@@ -708,29 +708,6 @@ def compute_correlations_motion_and_morphometric_metrics(final_df, path_out):
     generate_correlation_matrix(corr_df, output_pathname)
 
     output_pathname = os.path.join(path_out, 'pairplot_motion_and_morphometrics.png')
-    generate_pairplot(corr_df, output_pathname, logger)
-
-
-def plot_correlation_for_clinical_scores(clinical_df, path_out):
-    """
-    Plot and save correlation matrix for mJOA, mJOA subscores, and ASIA/GRASSP
-    """
-
-    # Identify columns with more than 25% nan values
-    cols_to_drop = clinical_df.columns[clinical_df.isnull().sum(axis=0) > 0.25 * len(clinical_df)]
-    # Drop these columns
-    print('Dropping columns with more than 25% nan values:\n {}'.format(cols_to_drop))
-    final_df = clinical_df.drop(columns=cols_to_drop)
-
-    # Drop rows with nan values
-    final_df = final_df.dropna(axis=0)
-    # Drop record_id column
-    corr_df = final_df.drop(columns=['record_id'])
-
-    output_pathname = os.path.join(path_out, 'corr_matrix_clinical_scores.png')
-    generate_correlation_matrix(corr_df, output_pathname)
-
-    output_pathname = os.path.join(path_out, 'pairplot_clinical_scores.png')
     generate_pairplot(corr_df, output_pathname, logger)
 
 

--- a/statistics/utils.py
+++ b/statistics/utils.py
@@ -230,3 +230,32 @@ def read_electrophysiology_anatomical_and_motion_file(file_path, df_participants
     electrophysiology_df = electrophysiology_df.set_index(['participant_id'])
 
     return anatomical_df, motion_df, electrophysiology_df
+
+
+def format_pvalue(p_value, alpha=0.001, decimal_places=3, include_space=False, include_equal=True):
+    """
+    Format p-value.
+    If the p-value is lower than alpha, format it to "<0.001", otherwise, round it to three decimals
+    :param p_value: input p-value as a float
+    :param alpha: significance level
+    :param decimal_places: number of decimal places the p-value will be rounded
+    :param include_space: include space or not (e.g., ' = 0.06')
+    :param include_equal: include equal sign ('=') to the p-value (e.g., '=0.06') or not (e.g., '0.06')
+    :return: p_value: the formatted p-value (e.g., '<0.05') as a str
+    """
+    if include_space:
+        space = ' '
+    else:
+        space = ''
+
+    # If the p-value is lower than alpha, return '<alpha' (e.g., <0.001)
+    if p_value < alpha:
+        p_value = space + "<" + space + str(alpha)
+    # If the p-value is greater than alpha, round it number of decimals specified by decimal_places
+    else:
+        if include_equal:
+            p_value = space + '=' + space + str(round(p_value, decimal_places))
+        else:
+            p_value = space + str(round(p_value, decimal_places))
+
+    return p_value

--- a/statistics/utils.py
+++ b/statistics/utils.py
@@ -116,3 +116,52 @@ def read_participants_file(file_path):
 
     return participants_pd
 
+
+def read_clinical_file(file_path):
+    """
+    Read file with clinical scores (mJOA, ASIA, GRASSP) and return Pandas DataFrame
+    :param file_path: path to excel file
+    :return: Pandas DataFrame
+    """
+    if os.path.isfile(file_path):
+        print('Reading: {}'.format(file_path))
+        clinical_df = pd.read_excel(file_path)
+    else:
+        raise FileNotFoundError(f'{file_path} not found')
+    # mJOA
+    mjoa = 'total_mjoa'         # baseline
+    mjoa_6m = 'total_mjoa.1'    # 6 months
+    mjoa_12m = 'total_mjoa.2'   # 12 months
+
+    # mJOA subscores
+    motor_dysfunction_UE_bl = 'motor_dysfunction_UE_bl'         # baseline
+    motor_dysfunction_LE_bl = 'motor_dysfunction_LE_bl'         # baseline
+    sensory_dysfunction_LE_bl = 'sensory_dysfunction_LE_bl'     # baseline
+    sphincter_dysfunction_bl = 'sphincter_dysfunction_bl'       # baseline
+
+    # ASIA/GRASSP - lt_cervical_tot
+    lt_cervical_tot = 'lt_cervical_tot'         # baseline
+    lt_cervical_tot_6m = 'lt_cervical_tot.1'    # 6 months
+    lt_cervical_tot_12m = 'lt_cervical_tot.2'   # 12 months
+    # ASIA/GRASSP - pp_cervical_tot
+    pp_cervical_tot = 'pp_cervical_tot'        # baseline
+    pp_cervical_tot_6m = 'pp_cervical_tot.1'   # 6 months
+    pp_cervical_tot_12m = 'pp_cervical_tot.2'  # 12 months
+    # ASIA/GRASSP - total_dorsal
+    total_dorsal = 'total_dorsal'        # baseline
+    total_dorsal_6m = 'total_dorsal.1'   # 6 months
+    total_dorsal_12m = 'total_dorsal.2'  # 12 months
+
+    # Read columns of interest from clinical file
+    clinical_df = clinical_df[['record_id', mjoa, mjoa_6m, mjoa_12m,
+                               motor_dysfunction_UE_bl, motor_dysfunction_LE_bl, sensory_dysfunction_LE_bl, sphincter_dysfunction_bl,
+                               lt_cervical_tot, lt_cervical_tot_6m, lt_cervical_tot_12m,
+                               pp_cervical_tot, pp_cervical_tot_6m, pp_cervical_tot_12m,
+                               total_dorsal, total_dorsal_6m, total_dorsal_12m]]
+
+    # Rename .1 to 6m and .2 to 12m
+    clinical_df.columns = clinical_df.columns.str.replace('.1', '_6m')
+    clinical_df.columns = clinical_df.columns.str.replace('.2', '_12m')
+
+    #print(clinical_df)
+    return clinical_df

--- a/statistics/utils.py
+++ b/statistics/utils.py
@@ -165,3 +165,69 @@ def read_clinical_file(file_path):
 
     #print(clinical_df)
     return clinical_df
+
+
+def read_electrophysiology_anatomical_and_motion_file(file_path, df_participants):
+    """
+    Read electrophysiology, anatomical, and motion data
+    :param file_path: path to excel file
+    :return anatomical_df: Pandas DataFrame with anatomical data
+    :return motion_df: Pandas DataFrame with motion data
+    :return electrophysiology_df: Pandas DataFrame with electrophysiology data
+    """
+    if os.path.isfile(file_path):
+        print('Reading: {}'.format(file_path))
+        df_all = pd.read_excel(file_path)
+    else:
+        raise FileNotFoundError(f'{file_path} not found')
+
+    # Anatomical data:
+    #   - adapted spinal canal occupation ratio (aSCOR) = spinal cord area/spinal canal area
+    #   - adapted maximum spinal cord compression (aMSCC) = ratio of spinal cord CSA in segment/spinal cord area at C2) - computed only at baseline so far
+    anatomical_df = df_all[['record_id', 'aSCOR_C2', 'aSCOR_C3', 'aSCOR_C4', 'aSCOR_C5', 'aSCOR_C6', 'aSCOR_C7',
+                            'aSCOR_C2_6mth', 'aSCOR_C3_6mth', 'aSCOR_C4_6mth', 'aSCOR_C5_6mth', 'aSCOR_C6_6mth', 'aSCOR_C7_6mth',
+                            'aSCOR_C2_12mth', 'aSCOR_C3_12mth', 'aSCOR_C4_12mth', 'aSCOR_C5_12mth', 'aSCOR_C6_12mth', 'aSCOR_C7_12mth',
+                            'aMSCC_C3toC2', 'aMSCC_C4toC2', 'aMSCC_C5toC2', 'aMSCC_C6toC2', 'aMSCC_C7toC2']]
+
+    # Rename 6mnt and 12mnt columns to 6m and 12m
+    anatomical_df.columns = anatomical_df.columns.str.replace('_6mth', '_6m')
+    anatomical_df.columns = anatomical_df.columns.str.replace('_12mth', '_12m')
+
+    # Insert participant_id column from df_participants to anatomical_df based on record_id
+    anatomical_df = pd.merge(anatomical_df, df_participants[['record_id', 'participant_id']], on='record_id',
+                             how='outer', sort=True)
+    anatomical_df = anatomical_df.set_index(['participant_id'])
+
+    # Segmental motion data:
+    #   - displacement [mm] = area under the curve of the motion plot
+    #   - amplitude [cm/s] = range from maximum positive to maximum negativ velocity values
+    motion_df = df_all[['record_id', 'C2_amp_ax_or_sag', 'C2_disp_ax_or_sag',
+                        'C3_amp_ax_or_sag', 'C3_disp_ax_or_sag',
+                        'C4_amp_ax_or_sag', 'C4_disp_ax_or_sag',
+                        'C5_amp_ax_or_sag', 'C5_disp_ax_or_sag',
+                        'C6_amp_ax_or_sag', 'C6_disp_ax_or_sag',
+                        'C7_amp_ax_or_sag']]
+
+    # Insert participant_id column from df_participants to motion_df based on record_id
+    motion_df = pd.merge(motion_df, df_participants[['record_id', 'participant_id']], on='record_id',
+                         how='outer', sort=True)
+    motion_df = motion_df.set_index(['participant_id'])
+
+    # Electrophysiology data:
+    # - dermatomal SEP (dSEP) with stimulation at C6 and C8 (only few pathologic results)
+    # - dermatomal contact heat evoked potentials (CHEPS) with stimulation at C6, C8 and T4
+    electrophysiology_df = df_all[['record_id', 'dSEP_C6_both_patho_bl', 'dSEP_C8_both_patho_bl', 'CHEPS_C6_patho_bl', 'CHEPS_C8_patho_bl', 'CHEPS_T4_grading_patho_bl',
+                                   'dSEP_C6_both_patho_6mth', 'dSEP_C8_both_patho_6mth', 'CHEPS_C6_patho_6mth', 'CHEPS_C8_patho_6mth', 'CHEPS_T4_patho_6mth',
+                                   'dSEP_C6_both_patho_12mth', 'dSEP_C8_both_patho_12mth', 'CHEPS_C6_patho_12mth', 'CHEPS_C8_patho_12mth', 'CHEPS_T4_patho_12mth',
+                                   'CHEPS_C6_diff_6mth_bl', 'CHEPS_C6_diff_12mth_bl', 'CHEPS_C8_diff_6mth_bl', 'CHEPS_C8_diff_12mth_bl', 'CHEPS_T4_diff_6mth_bl', 'CHEPS_T4_diff_12mth_bl']]
+
+    # Rename 6mnt and 12mnt columns to 6m and 12m
+    electrophysiology_df.columns = electrophysiology_df.columns.str.replace('_6mth', '_6m')
+    electrophysiology_df.columns = electrophysiology_df.columns.str.replace('_12mth', '_12m')
+
+    # Insert participant_id column from df_participants to electrophysiology_df based on record_id
+    electrophysiology_df = pd.merge(electrophysiology_df, df_participants[['record_id', 'participant_id']],
+                                    on='record_id', how='outer', sort=True)
+    electrophysiology_df = electrophysiology_df.set_index(['participant_id'])
+
+    return anatomical_df, motion_df, electrophysiology_df

--- a/statistics/utils.py
+++ b/statistics/utils.py
@@ -163,7 +163,6 @@ def read_clinical_file(file_path):
     clinical_df.columns = clinical_df.columns.str.replace('.1', '_6m')
     clinical_df.columns = clinical_df.columns.str.replace('.2', '_12m')
 
-    #print(clinical_df)
     return clinical_df
 
 

--- a/statistics/utils.py
+++ b/statistics/utils.py
@@ -1,0 +1,11 @@
+import argparse
+
+
+class SmartFormatter(argparse.HelpFormatter):
+
+    def _split_lines(self, text, width):
+        if text.startswith('R|'):
+            return text[2:].splitlines()
+        # this is the RawTextHelpFormatter._split_lines
+        return argparse.HelpFormatter._split_lines(self, text, width)
+

--- a/statistics/utils.py
+++ b/statistics/utils.py
@@ -2,7 +2,10 @@ import os
 import re
 import argparse
 
+import numpy as np
 import pandas as pd
+
+from scipy.stats import spearmanr
 
 DICT_DISC_LABELS = {
                     'C1/C2': 2,
@@ -259,3 +262,13 @@ def format_pvalue(p_value, alpha=0.001, decimal_places=3, include_space=False, i
             p_value = space + str(round(p_value, decimal_places))
 
     return p_value
+
+
+def compute_spearmans(a, b):
+    """
+    Compute Spearman's correlation coefficient and p-value for two arrays.
+    """
+    a = np.array(a)
+    b = np.array(b)
+    return spearmanr(a, b)
+

--- a/statistics/utils.py
+++ b/statistics/utils.py
@@ -103,3 +103,16 @@ def read_metric_file(file_path, dict_exclude_subj, df_participants):
     return df_morphometrics
 
 
+def read_participants_file(file_path):
+    """
+    Read participants.tsv file and return Pandas DataFrame
+    :param file_path: path to participants.tsv file
+    :return: Pandas DataFrame
+    """
+    if os.path.isfile(file_path):
+        participants_pd = pd.read_csv(file_path, sep='\t')
+    else:
+        raise FileNotFoundError(f'{file_path} not found')
+
+    return participants_pd
+

--- a/statistics/utils.py
+++ b/statistics/utils.py
@@ -1,4 +1,17 @@
+import os
+import re
 import argparse
+
+import pandas as pd
+
+DICT_DISC_LABELS = {
+                    'C1/C2': 2,
+                    'C2/C3': 3,
+                    'C3/C4': 4,
+                    'C4/C5': 5,
+                    'C5/C6': 6,
+                    'C6/C7': 7
+                    }
 
 
 class SmartFormatter(argparse.HelpFormatter):
@@ -8,4 +21,85 @@ class SmartFormatter(argparse.HelpFormatter):
             return text[2:].splitlines()
         # this is the RawTextHelpFormatter._split_lines
         return argparse.HelpFormatter._split_lines(self, text, width)
+
+
+def fetch_participant_id(filename):
+    """
+    Get participant ID from the input BIDS-compatible filename
+    :param filename_path: input nifti filename (e.g., sub-001_ses-01_T1w.nii.gz)
+    :return: participant_id: subject ID (e.g., sub-001)
+    """
+    participant_id = re.search('sub-(.*?)[_/]', filename)  # [_/] slash or underscore
+    participant_id = participant_id.group(0)[:-1] if participant_id else ""  # [:-1] removes the last underscore or slash
+
+    return participant_id
+
+
+def read_metric_file(file_path, dict_exclude_subj, df_participants):
+    """
+    Read CSV file with computed metrics and return Pandas DataFrame
+    :param file_path: path to the CSV file with computed metrics
+    :param dict_exclude_subj: list with subjects to exclude
+    :param df_participants: Pandas DataFrame with participants.tsv file
+    :return: Pandas DataFrame
+    """
+    # Load CSV file
+    if os.path.isfile(file_path):
+        df_morphometrics = pd.read_csv(file_path)
+    else:
+        raise FileNotFoundError(f'{file_path} not found')
+
+    # Fetch participant_id from filename
+    list_participant_id = list()
+    # Loop across rows
+    for index, row in df_morphometrics.iterrows():
+        participant_id = fetch_participant_id(row['filename'])
+        list_participant_id.append(participant_id)
+    # Insert list of subIDs into pandas DF
+    df_morphometrics.insert(1, "participant_id", list_participant_id)
+    # Delete column 'filename'
+    df_morphometrics.drop('filename', axis=1, inplace=True)
+
+    # Merge df_participants['maximum_stenosis'] to df_morphometrics
+    df_morphometrics = pd.merge(df_morphometrics, df_participants[['participant_id', 'maximum_stenosis']],
+                                on='participant_id', how='left')
+    # Change coding of 'maximum_stenosis' column (e.g., from to 'C1/C2' to '2') based on DICT_DISC_LABELS
+    df_morphometrics['level'] = df_morphometrics['maximum_stenosis'].map(DICT_DISC_LABELS)
+    # NOTE: after this merge, df_morphometrics has the following columns:
+    #   'compression_level' - obtained from sct_compute_compression function based on vert labeling, example 5
+    #   'maximum_stenosis' - obtained from participants.tsv file, example 'C5/C6'
+    #   'level' - obtained from participants.tsv file and recoded using DICT_DISC_LABELS, example 6
+
+    # Subjects might have multiple levels of compression --> keep only the maximally compressed level (MCL)
+    # Get unique list of subjects
+    unique_subjects = df_morphometrics['participant_id'].unique().tolist()
+    # Loop across subjects
+    for sub in unique_subjects:
+        # First, get the maximally compressed level
+        max_level = df_participants.loc[df_participants['participant_id'] == sub, 'maximum_stenosis'].to_list()[0]
+        # Second, get all the compressed levels
+        all_compressed_levels = df_participants.loc[df_participants['participant_id'] == sub, 'stenosis'].to_list()[
+            0].split(', ')
+        # Third, get the index of the maximally compressed level
+        idx_max = all_compressed_levels.index(max_level)
+
+        # Get all rows of the subject from df_motphometrics
+        # Note: we are resetting the index to be able to use the index as a list, also we use the drop parameter to
+        # avoid the old index being added as a column
+        df_sub = df_morphometrics.loc[df_morphometrics['participant_id'] == sub].reset_index(drop=True)
+
+        # Check if the maximally compressed level is in the axial FOV (i.e., in the df_sub)
+        if idx_max not in df_sub.index.to_list():
+            print(f'Maximum level of compression {max_level} is not in axial FOV, excluding {sub}')
+            df_morphometrics.drop(df_morphometrics.loc[df_morphometrics['participant_id'] == sub].index, inplace=True)
+            dict_exclude_subj.append(sub)
+        # If the maximally compressed level is in the axial FOV, keep only this row
+        else:
+            # Get 'slice(I->S)' of df_sub with the maximally compressed level
+            slice_max = df_sub.loc[idx_max, 'slice(I->S)']
+            df_morphometrics = df_morphometrics.drop(df_morphometrics.loc[(df_morphometrics['participant_id'] == sub) &
+                                                          (df_morphometrics['slice(I->S)'] != slice_max)].index)
+
+    return df_morphometrics
+
 

--- a/statistics/utils/generate_figures.py
+++ b/statistics/utils/generate_figures.py
@@ -192,3 +192,26 @@ def gen_chart_weight_height(df_reg, path_out, logger=None):
     plt.savefig(fname_fig, dpi=200, bbox_inches="tight")
     plt.close()
     logger.info(f'Created: {fname_fig}.\n')
+
+
+def plot_correlation_for_clinical_scores(clinical_df, path_out, logger=None):
+    """
+    Plot and save correlation matrix for mJOA, mJOA subscores, and ASIA/GRASSP
+    """
+
+    # Identify columns with more than 25% nan values
+    cols_to_drop = clinical_df.columns[clinical_df.isnull().sum(axis=0) > 0.25 * len(clinical_df)]
+    # Drop these columns
+    print('Dropping columns with more than 25% nan values:\n {}'.format(cols_to_drop))
+    final_df = clinical_df.drop(columns=cols_to_drop)
+
+    # Drop rows with nan values
+    final_df = final_df.dropna(axis=0)
+    # Drop record_id column
+    corr_df = final_df.drop(columns=['record_id'])
+
+    output_pathname = os.path.join(path_out, 'corr_matrix_clinical_scores.png')
+    generate_correlation_matrix(corr_df, output_pathname)
+
+    output_pathname = os.path.join(path_out, 'pairplot_clinical_scores.png')
+    generate_pairplot(corr_df, output_pathname, logger)

--- a/statistics/utils/generate_figures.py
+++ b/statistics/utils/generate_figures.py
@@ -6,6 +6,16 @@ import matplotlib.pyplot as plt
 
 from utils import format_pvalue, compute_spearmans
 
+METRICS = [
+    'area_ratio',
+    'diameter_AP_ratio',
+    'diameter_RL_ratio',
+    'eccentricity_ratio',
+    'solidity_ratio',
+]
+
+METRICS_NORM = [metric + '_PAM50_normalized' for metric in METRICS]
+
 
 def gen_chart_norm_vs_no_norm(df, metric, path_out="", logger=None):
     """
@@ -214,4 +224,22 @@ def plot_correlation_for_clinical_scores(clinical_df, path_out, logger=None):
     generate_correlation_matrix(corr_df, output_pathname)
 
     output_pathname = os.path.join(path_out, 'pairplot_clinical_scores.png')
+    generate_pairplot(corr_df, output_pathname, logger)
+
+
+def plot_correlations_motion_and_morphometric_metrics(final_df, path_out, logger=None):
+    """
+    Plot and save correlation matrix for motion data (displacement and amplitude) and morphometric metrics
+    """
+
+    # Keep only motion and morphometric metrics
+    final_df = final_df[['amp_ax_or_sag', 'disp_ax_or_sag'] + METRICS + METRICS_NORM]
+
+    # Drop rows with nan values
+    corr_df = final_df.dropna(axis=0)
+
+    output_pathname = os.path.join(path_out, 'corr_matrix_motion_and_morphometrics.png')
+    generate_correlation_matrix(corr_df, output_pathname)
+
+    output_pathname = os.path.join(path_out, 'pairplot_motion_and_morphometrics.png')
     generate_pairplot(corr_df, output_pathname, logger)

--- a/statistics/utils/generate_figures.py
+++ b/statistics/utils/generate_figures.py
@@ -1,0 +1,194 @@
+import os
+
+import pandas as pd
+import seaborn as sns
+import matplotlib.pyplot as plt
+
+from utils import format_pvalue, compute_spearmans
+
+
+def gen_chart_norm_vs_no_norm(df, metric, path_out="", logger=None):
+    """
+    Plot data and a linear regression model fit of normalized vs non-normalized metric
+    """
+    sns.set_style("ticks", {'axes.grid': True})
+    plt.figure()
+    fig, ax = plt.subplots()
+    #ax.set_box_aspect(1)
+    # MSCC with mJOA
+    metric_norm = metric+'_PAM50_normalized'
+    x_vals = df[metric]
+    y_vals_mscc = df[metric_norm]
+    r_mscc, p_mscc = compute_spearmans(x_vals, y_vals_mscc)
+    logger.info(f'{metric} ratio: Spearman r = {r_mscc} and p = {p_mscc}')
+    sns.regplot(x=x_vals, y=y_vals_mscc)
+    plt.ylabel((metric_norm + ' ratio'), fontsize=16)
+    plt.xlabel(metric + ' ratio', fontsize=16)
+    plt.xlim([min(x_vals) -1, max(x_vals)+1])
+    plt.tight_layout()
+    plt.text(0.03, 0.90, 'r = {}\np{}'.format(round(r_mscc, 2), format_pvalue(p_mscc, alpha=0.001, include_space=True)),
+             fontsize=10, transform=ax.transAxes,
+             bbox=dict(boxstyle='round', facecolor='white', alpha=0.95, edgecolor='lightgrey'))
+    plt.xticks(fontsize=12)
+    plt.yticks(fontsize=12)
+    # save figure
+    fname_fig = os.path.join(path_out, 'scatter_norm_no_norm_' + metric + '_mjoa.png')
+    plt.savefig(fname_fig, dpi=200, bbox_inches="tight")
+    plt.close()
+    logger.info(f'Created: {fname_fig}.\n')
+
+
+def gen_chart_corr_mjoa_mscc(df, metric, mjoa, path_out="", logger=None):
+    """
+    Plot data and a linear regression model fit of metric vs mJOA
+    """
+    sns.set_style("ticks", {'axes.grid': True})
+    plt.figure()
+    fig, ax = plt.subplots()
+    #ax.set_box_aspect(1)
+    # MSCC with mJOA
+    x_vals = df[mjoa]
+    y_vals_mscc = df[metric]
+    metric_norm = metric+'_PAM50_normalized'
+    y_vals_mscc_norm = df[metric_norm]
+
+    r_mscc, p_mscc = compute_spearmans(x_vals, y_vals_mscc)
+    r_mscc_norm, p_mscc_norm = compute_spearmans(x_vals, y_vals_mscc_norm)
+
+    logger.info(f'{metric} ratio: Spearman r = {r_mscc} and p = {p_mscc}')
+    logger.info(f'{metric_norm} ratio: Spearman r = {r_mscc_norm} and p = {p_mscc_norm}')
+
+    sns.regplot(x=x_vals, y=y_vals_mscc, label=(metric+' ratio')) #ci=None,
+    sns.regplot(x=x_vals, y=y_vals_mscc_norm, color='crimson', label=metric_norm) # ci=None,
+    plt.ylabel(metric, fontsize=16)
+    plt.xlabel('mJOA', fontsize=16)
+    plt.xlim([min(x_vals)-1, max(x_vals)+1])
+    plt.tight_layout()
+    # Insert text with corr coef and pval
+    plt.text(0.02, 0.03, 'r = {}\np{}'.format(round(r_mscc, 2), format_pvalue(p_mscc, alpha=0.001, include_space=True)),
+             fontsize=10, transform=ax.transAxes,
+             bbox=dict(boxstyle='round', facecolor='white', alpha=0.95, edgecolor='lightgrey'))
+    plt.legend(fontsize=12, bbox_to_anchor=(0.5, 1.12), loc="upper center", ncol=2, framealpha=0.95, handletextpad=0.1)
+    plt.xticks(fontsize=12)
+    plt.yticks(fontsize=12)
+    # save figure
+    fname_fig = os.path.join(path_out, 'scatter_' + metric + '_mjoa.png')
+    plt.savefig(fname_fig, dpi=200, bbox_inches="tight")
+    plt.close()
+    logger.info(f'Created: {fname_fig}.\n')
+
+    # Create pairplot to seperate with therpeutic decision
+    plt.figure()
+    g = sns.pairplot(df, x_vars=mjoa, y_vars=metric_norm, kind='reg', hue='therapeutic_decision', palette="Set1",
+                     height=4, plot_kws={'scatter_kws': {'alpha': 0.6}, 'line_kws': {'lw': 4}})
+    g._legend.remove()
+    plt.xlim([min(x_vals)-1, max(x_vals)+1])
+    plt.legend(title='Therapeutic decision', loc='lower left', labels=['conservative', 'operative'])
+    plt.tight_layout()
+    fname_fig = os.path.join(path_out, 'pairwise_plot_' + metric_norm + '.png')
+    plt.savefig(fname_fig)
+    plt.close()
+    logger.info(f'Created: {fname_fig}.\n')
+
+
+def compare_mjoa_between_therapeutic_decision(df_reg, path_out, logger=None):
+    """
+    Compare mJOA change between subjects with therapeutic_decision == 0 and subjects with therapeutic_decision == 1.
+    """
+    # Get difference between mjoa_6m and mjoa
+    df_reg['mjoa_6m_diff'] = df_reg['mjoa'] - df_reg['mjoa_6m']
+    df_6m = df_reg.dropna(axis=0, subset=['mjoa_6m_diff'])
+    print(df_6m[['therapeutic_decision', 'mjoa_6m_diff']].groupby(['therapeutic_decision']).agg(['mean', 'std']))
+
+    # Get difference between mjoa_12m and mjoa
+    df_reg['mjoa_12m_diff'] = df_reg['mjoa'] - df_reg['mjoa_12m']
+    df_12m = df_reg.dropna(axis=0, subset=['mjoa_12m_diff'])
+
+    print(df_12m[['therapeutic_decision', 'mjoa_12m_diff']].groupby(['therapeutic_decision']).agg(['mean', 'std']))
+
+    # Create DataFrame with three columns: therapeutic_decision, mjoa_diff, and mjoa_6m_12m (6m or 12m) for easy
+    # plotting using sns hue option
+    df_6m_temp = pd.DataFrame(columns=['therapeutic_decision', 'mjoa_diff', 'mjoa_6m_12m'])
+    df_6m_temp['therapeutic_decision'] = df_6m['therapeutic_decision']
+    df_6m_temp['mjoa_diff'] = df_6m['mjoa_6m_diff']
+    df_6m_temp['mjoa_6m_12m'] = '6 months'
+    df_12_temp = pd.DataFrame(columns=['therapeutic_decision', 'mjoa_diff', 'mjoa_6m_12m'])
+    df_12_temp['therapeutic_decision'] = df_12m['therapeutic_decision']
+    df_12_temp['mjoa_diff'] = df_12m['mjoa_12m_diff']
+    df_12_temp['mjoa_6m_12m'] = '12 months'
+    df_final_temp = pd.concat([df_6m_temp, df_12_temp])
+
+    fig, ax = plt.subplots(figsize=(6, 6))
+    # Plot scatter plot and boxplot
+    sns.stripplot(x='mjoa_6m_12m', y='mjoa_diff', hue='therapeutic_decision', data=df_final_temp, ax=ax, dodge=True,
+                  edgecolor='black', linewidth=1, legend=False)
+    sns.boxplot(x='mjoa_6m_12m', y='mjoa_diff', hue='therapeutic_decision', data=df_final_temp, ax=ax, dodge=True,
+                showfliers = False)
+    # Change x axis label
+    ax.set_xlabel('')
+    # Change y axis label
+    ax.set_ylabel('mJOA difference', fontsize=14)
+    # Increase tick label size
+    ax.tick_params(axis='both', which='major', labelsize=14)
+    # save figure
+    fname_fig = os.path.join(path_out, 'boxplot_therapeutic_decision_mjoa.png')
+    plt.savefig(fname_fig, dpi=200, bbox_inches="tight")
+    plt.close()
+    logger.info(f'Created: {fname_fig}.\n')
+
+
+def generate_correlation_matrix(df, output_pathname, logger=None):
+    """
+    Plot and save correlation matrix as .csv and .png
+    df: dataframe to use
+    output_pathname: path to save the correlation matrix
+    """
+
+    sns.set(font_scale=1)
+    corr_matrix = df.corr()
+    corr_matrix.to_csv(output_pathname.replace('.png', '.csv'))
+    corr_matrix = corr_matrix.round(2)
+    fig, ax = plt.subplots(figsize=(10, 10))
+    sns.heatmap(corr_matrix, annot=True, linewidths=.5, ax=ax)
+    # Put level and number of subjects to the title
+    ax.set_title('Number of subjects = {}'.format(len(df)))
+    plt.savefig(output_pathname, dpi=300, bbox_inches='tight')
+    plt.close()
+    logger.info('Correlation matrix saved to: {}'.format(output_pathname))
+
+
+def generate_pairplot(df, output_pathname, logger=None):
+    """"
+    Plot and save pairplot
+    df: dataframe to use
+    path_out: path to save the pairplot
+    """
+    logger.info('Generating pairplot...(it may take a while)...')
+    sns.set(font_scale=1.5)
+    sns.pairplot(df, kind="reg", diag_kws={'color': 'orange'})
+    plt.savefig(output_pathname, dpi=300, bbox_inches='tight')
+    plt.close()
+    logger.info('Pairplot saved to: {}'.format(output_pathname))
+
+
+def gen_chart_weight_height(df_reg, path_out, logger=None):
+    """
+    Plot weight and height relationship per sex
+    """
+
+    # Drop nan for weight and height
+    df_reg.dropna(axis=0, subset=['weight', 'height'], inplace=True)
+    print(f'Number of subjects after dropping nan for weight and height: {len(df_reg)}')
+
+    sns.regplot(x='weight', y='height', data=df_reg[df_reg['sex'] == 1], label='Male', color='blue')
+    sns.regplot(x='weight', y='height', data=df_reg[df_reg['sex'] == 0], label='Female', color='red')
+    plt.legend()
+    # x axis label
+    plt.xlabel('Weight (kg)')
+    # y axis label
+    plt.ylabel('Height (m)')
+    # save figure
+    fname_fig = os.path.join(path_out, 'regplot_weight_height_relationship_persex.png')
+    plt.savefig(fname_fig, dpi=200, bbox_inches="tight")
+    plt.close()
+    logger.info(f'Created: {fname_fig}.\n')

--- a/statistics/utils/generate_figures.py
+++ b/statistics/utils/generate_figures.py
@@ -221,7 +221,7 @@ def plot_correlation_for_clinical_scores(clinical_df, path_out, logger=None):
     corr_df = final_df.drop(columns=['record_id'])
 
     output_pathname = os.path.join(path_out, 'corr_matrix_clinical_scores.png')
-    generate_correlation_matrix(corr_df, output_pathname)
+    generate_correlation_matrix(corr_df, output_pathname, logger)
 
     output_pathname = os.path.join(path_out, 'pairplot_clinical_scores.png')
     generate_pairplot(corr_df, output_pathname, logger)
@@ -239,7 +239,7 @@ def plot_correlations_motion_and_morphometric_metrics(final_df, path_out, logger
     corr_df = final_df.dropna(axis=0)
 
     output_pathname = os.path.join(path_out, 'corr_matrix_motion_and_morphometrics.png')
-    generate_correlation_matrix(corr_df, output_pathname)
+    generate_correlation_matrix(corr_df, output_pathname, logger)
 
     output_pathname = os.path.join(path_out, 'pairplot_motion_and_morphometrics.png')
     generate_pairplot(corr_df, output_pathname, logger)
@@ -267,7 +267,7 @@ def plot_correlations_anatomical_and_morphometric_metrics(final_df, path_out, lo
         final_df = final_df.dropna(axis=0)
 
         output_pathname = os.path.join(path_out, 'corr_matrix_anatomical_and_morphometrics_' + key + '.png')
-        generate_correlation_matrix(final_df, output_pathname)
+        generate_correlation_matrix(final_df, output_pathname, logger)
 
         output_pathname = os.path.join(path_out, 'pairplot_anatomical_and_morphometrics_' + key + '.png')
         generate_pairplot(final_df, output_pathname, logger)

--- a/statistics/utils/generate_figures.py
+++ b/statistics/utils/generate_figures.py
@@ -243,3 +243,31 @@ def plot_correlations_motion_and_morphometric_metrics(final_df, path_out, logger
 
     output_pathname = os.path.join(path_out, 'pairplot_motion_and_morphometrics.png')
     generate_pairplot(corr_df, output_pathname, logger)
+
+
+def plot_correlations_anatomical_and_morphometric_metrics(final_df, path_out, logger=None):
+    """
+    Plot and save correlation matrix and pairplot for anatomical (aSCOR and aMSCC) and morphometric metrics
+    """
+
+    # Keep only anatomical and morphometric metrics
+    metrics_dict = {'all_metrics': METRICS + METRICS_NORM + ['aSCOR', 'aMSCC'],
+                    'area_ratio': ['area_ratio', 'area_ratio_PAM50_normalized', 'aSCOR', 'aMSCC']}
+
+    # Either all metrics or only area
+    for key, value in metrics_dict.items():
+        final_df = final_df[value]
+
+        # Make 'aSCOR' and 'aMSCC' first and second columns
+        cols = final_df.columns.tolist()
+        cols = cols[-2:] + cols[:-2]
+        final_df = final_df[cols]
+
+        # Drop rows with nan values
+        final_df = final_df.dropna(axis=0)
+
+        output_pathname = os.path.join(path_out, 'corr_matrix_anatomical_and_morphometrics_' + key + '.png')
+        generate_correlation_matrix(final_df, output_pathname)
+
+        output_pathname = os.path.join(path_out, 'pairplot_anatomical_and_morphometrics_' + key + '.png')
+        generate_pairplot(final_df, output_pathname, logger)

--- a/statistics/utils/generate_figures.py
+++ b/statistics/utils/generate_figures.py
@@ -4,7 +4,7 @@ import pandas as pd
 import seaborn as sns
 import matplotlib.pyplot as plt
 
-from utils import format_pvalue, compute_spearmans
+from .utils import format_pvalue, compute_spearmans
 
 METRICS = [
     'area_ratio',

--- a/statistics/utils/read_files.py
+++ b/statistics/utils/read_files.py
@@ -1,11 +1,7 @@
 import os
 import re
-import argparse
 
-import numpy as np
 import pandas as pd
-
-from scipy.stats import spearmanr
 
 DICT_DISC_LABELS = {
                     'C1/C2': 2,
@@ -15,15 +11,6 @@ DICT_DISC_LABELS = {
                     'C5/C6': 6,
                     'C6/C7': 7
                     }
-
-
-class SmartFormatter(argparse.HelpFormatter):
-
-    def _split_lines(self, text, width):
-        if text.startswith('R|'):
-            return text[2:].splitlines()
-        # this is the RawTextHelpFormatter._split_lines
-        return argparse.HelpFormatter._split_lines(self, text, width)
 
 
 def fetch_participant_id(filename):
@@ -233,42 +220,3 @@ def read_electrophysiology_anatomical_and_motion_file(file_path, df_participants
     electrophysiology_df = electrophysiology_df.set_index(['participant_id'])
 
     return anatomical_df, motion_df, electrophysiology_df
-
-
-def format_pvalue(p_value, alpha=0.001, decimal_places=3, include_space=False, include_equal=True):
-    """
-    Format p-value.
-    If the p-value is lower than alpha, format it to "<0.001", otherwise, round it to three decimals
-    :param p_value: input p-value as a float
-    :param alpha: significance level
-    :param decimal_places: number of decimal places the p-value will be rounded
-    :param include_space: include space or not (e.g., ' = 0.06')
-    :param include_equal: include equal sign ('=') to the p-value (e.g., '=0.06') or not (e.g., '0.06')
-    :return: p_value: the formatted p-value (e.g., '<0.05') as a str
-    """
-    if include_space:
-        space = ' '
-    else:
-        space = ''
-
-    # If the p-value is lower than alpha, return '<alpha' (e.g., <0.001)
-    if p_value < alpha:
-        p_value = space + "<" + space + str(alpha)
-    # If the p-value is greater than alpha, round it number of decimals specified by decimal_places
-    else:
-        if include_equal:
-            p_value = space + '=' + space + str(round(p_value, decimal_places))
-        else:
-            p_value = space + str(round(p_value, decimal_places))
-
-    return p_value
-
-
-def compute_spearmans(a, b):
-    """
-    Compute Spearman's correlation coefficient and p-value for two arrays.
-    """
-    a = np.array(a)
-    b = np.array(b)
-    return spearmanr(a, b)
-

--- a/statistics/utils/utils.py
+++ b/statistics/utils/utils.py
@@ -1,6 +1,7 @@
 import argparse
 
 import numpy as np
+import statsmodels.api as sm
 
 from scipy.stats import spearmanr
 
@@ -51,3 +52,17 @@ def compute_spearmans(a, b):
     b = np.array(b)
     return spearmanr(a, b)
 
+
+def fit_reg(X, y, method):
+    """
+    Fit either linear regression (the dependent variable is non-binary) or logistic regression (the dependent variable
+    is binary) and print summary.
+    Args:
+        method: 'linear' or 'logistic'
+    """
+    if method == 'linear':
+        logit_model = sm.OLS(y, X)      # Ordinary Least Squares Regression
+    elif method == 'logistic':
+        logit_model = sm.Logit(y, X)    # Logistic Regression
+    result = logit_model.fit()
+    print(result.summary2())

--- a/statistics/utils/utils.py
+++ b/statistics/utils/utils.py
@@ -1,0 +1,53 @@
+import argparse
+
+import numpy as np
+
+from scipy.stats import spearmanr
+
+
+class SmartFormatter(argparse.HelpFormatter):
+
+    def _split_lines(self, text, width):
+        if text.startswith('R|'):
+            return text[2:].splitlines()
+        # this is the RawTextHelpFormatter._split_lines
+        return argparse.HelpFormatter._split_lines(self, text, width)
+
+
+def format_pvalue(p_value, alpha=0.001, decimal_places=3, include_space=False, include_equal=True):
+    """
+    Format p-value.
+    If the p-value is lower than alpha, format it to "<0.001", otherwise, round it to three decimals
+    :param p_value: input p-value as a float
+    :param alpha: significance level
+    :param decimal_places: number of decimal places the p-value will be rounded
+    :param include_space: include space or not (e.g., ' = 0.06')
+    :param include_equal: include equal sign ('=') to the p-value (e.g., '=0.06') or not (e.g., '0.06')
+    :return: p_value: the formatted p-value (e.g., '<0.05') as a str
+    """
+    if include_space:
+        space = ' '
+    else:
+        space = ''
+
+    # If the p-value is lower than alpha, return '<alpha' (e.g., <0.001)
+    if p_value < alpha:
+        p_value = space + "<" + space + str(alpha)
+    # If the p-value is greater than alpha, round it number of decimals specified by decimal_places
+    else:
+        if include_equal:
+            p_value = space + '=' + space + str(round(p_value, decimal_places))
+        else:
+            p_value = space + str(round(p_value, decimal_places))
+
+    return p_value
+
+
+def compute_spearmans(a, b):
+    """
+    Compute Spearman's correlation coefficient and p-value for two arrays.
+    """
+    a = np.array(a)
+    b = np.array(b)
+    return spearmanr(a, b)
+


### PR DESCRIPTION
This PR cleans the main `compute_stats_zurich` script by introducing the `utils` folder:

```
└── utils
    ├── generate_figures.py             # functions for plotting
    ├── read_files.py                   # functions for reading input files
    └── utils.py                        # various utility functions
```

The PR also makes the script compatible with XLSX files under the `phenotype` folder (context [here](https://github.com/neuropoly/data-management/issues/256)).